### PR TITLE
Fix failing page test with double-encoded path

### DIFF
--- a/test/page.test.js
+++ b/test/page.test.js
@@ -26,7 +26,7 @@ describe('Page', () => {
         it('can construct a new Page object using page path', () => {
             var page = new Page('foo/bar');
             expect(page).toBeDefined();
-            expect(page._id).toBe('=foo/bar');
+            expect(page._id).toBe('=foo%252Fbar');
         });
         it('can construct a new Page object using \'home\'', () => {
             var page = new Page('home');


### PR DESCRIPTION
Reviewed by @killsunday.

When sent in as a string, the page ID should be preceded by '=' and double-URI-encoded.  The test should reflect this.