### PR TITLE
Slight refactor of Page.setContents() parsing

### DIFF
--- a/models/pageEdit.model.js
+++ b/models/pageEdit.model.js
@@ -1,0 +1,13 @@
+import modelHelper from './modelHelper';
+import pageModel from './page.model';
+let pageEditModel = {
+    parse(data) {
+        let obj = modelHelper.fromJson(data);
+        let parsed = {
+            status: obj['@status'],
+            page: pageModel.parse(obj.page)
+        };
+        return parsed;
+    }
+};
+export default pageEditModel;

--- a/page.pro.js
+++ b/page.pro.js
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 import Page from './page';
-import pageModel from './models/page.model';
 import pageMoveModel from './models/pageMove.model';
+import pageEditModel from './models/pageEdit.model';
 export default class PagePro extends Page {
     constructor(id = 'home') {
         super(id);
@@ -43,11 +43,6 @@ export default class PagePro extends Page {
         Object.keys(params).forEach((key) => {
             contentsParams[key] = params[key];
         });
-        return this._plug.at('contents').withParams(contentsParams).post(contents, 'text/plain; charset=utf-8').then((data) => {
-            if(typeof data === 'string') {
-                data = JSON.parse(data);
-            }
-            return pageModel.parse(data.page);
-        });
+        return this._plug.at('contents').withParams(contentsParams).post(contents, 'text/plain; charset=utf-8').then(pageEditModel.parse);
     }
 }

--- a/test/mock/page.mock.js
+++ b/test/mock/page.mock.js
@@ -594,3 +594,22 @@ Mocks.pageFilesEmpty = `{
     "@totalcount":"7",
     "@href":"https://marsdev.mindtouch.dev/@api/deki/pages/362/files"
 }`;
+Mocks.pageSetContents = `{
+  "@status": "success",
+  "page": {
+    "@id": "564",
+    "@draft.state": "inactive",
+    "@href": "http://marsdev.mindtouch.dev/@api/deki/pages/564?redirects=0",
+    "@deleted": "false",
+    "@revision": "2",
+    "date.created": "Mon, 07 Dec 2015 21:34:55 GMT",
+    "language": "en-US",
+    "namespace": "main",
+    "path": {
+      "@seo": "true",
+      "#text": "Category_1/Guide_1/Page_Title_2"
+    },
+    "title": "Page Title 2",
+    "uri.ui": "http://marsdev.mindtouch.dev/Category_1/Guide_1/Page_Title_2"
+  }
+}`;

--- a/test/page.pro.test.js
+++ b/test/page.pro.test.js
@@ -105,5 +105,27 @@ describe('Page Pro', () => {
                 done();
             });
         });
+        it('can set the page contents', (done) => {
+            let setUri = '/@api/deki/pages/123/contents?';
+            jasmine.Ajax.stubRequest(new RegExp(setUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageSetContents });
+            page.setContents('Sample contents').then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can set the page contents with options', (done) => {
+            let setUri = '/@api/deki/pages/123/contents?';
+            jasmine.Ajax.stubRequest(new RegExp(setUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageSetContents });
+            page.setContents('Sample contents', { edittime: 'now' }).then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fail when setting invalid page contents', (done) => {
+            page.setContents({}).catch((e) => {
+                expect(e.message).toBe('Contents should be string.');
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
Added a contents model for editor response, and changed the parsing in setContents() to use it.
Added tests for full coverage.

Reviewed by @trypton 