### PR TITLE
Add Context ID Definition and Mapping API access to martian

### DIFF
--- a/contextId.js
+++ b/contextId.js
@@ -1,0 +1,63 @@
+import Plug from './plug';
+import contextIdsModel from 'models/contextIds.model';
+import contextIdModel from 'models/contextId.model';
+import contextMapsModel from 'models/contextMaps.model';
+import contextMapModel from 'models/contextMap.model';
+let definitionsPlug = new Plug().at('@api', 'deki', 'contexts');
+class ContextDefinition {
+    static getDefinitions() {
+        return definitionsPlug.get().then(contextIdsModel.parse);
+    }
+    static addDefinition(id, description = '') {
+        if(!id) {
+            return Promise.reject(new Error('an ID must be supplied to add a definintion'));
+        }
+        let addRequest = `<contexts><context><id>${id}</id><description>${description}</description></context></contexts>`;
+        return definitionsPlug.post(addRequest, 'application/xml; charset=utf-8').then(contextIdModel.parse);
+    }
+    constructor(id) {
+        if(!id) {
+            throw new Error('an ID must be supplied to create a new ContextDefinition');
+        }
+        this.id = id;
+        this.plug = definitionsPlug.at(id);
+    }
+    getInfo() {
+        return this.plug.get().then(contextIdModel.parse);
+    }
+    updateDescription(description = '') {
+        let updateRequest = `<context><id>${this.id}</id><description>${description}</description></context>`;
+        return this.plug.put(updateRequest, 'application/xml; charset=utf-8').then(contextIdModel.parse);
+    }
+    delete() {
+        return this.plug.delete();
+    }
+}
+let mapsPlug = new Plug().at('@api', 'deki', 'contextmaps').withParam('verbose', 'true');
+class ContextMap {
+    static getMaps() {
+        return mapsPlug.get().then(contextMapsModel.parse);
+    }
+    constructor(language, id) {
+        if(!id || !language) {
+            throw new Error('an ID and language must be supplied to create a new ContextMap');
+        }
+        this.id = id;
+        this.language = language;
+        this.plug = mapsPlug.at(language, id);
+    }
+    getInfo() {
+        return this.plug.get().then(contextMapModel.parse);
+    }
+    update(pageId) {
+        if(!pageId) {
+            return Promise.reject(new Error('a page ID must be supplied in order to update a mapping'));
+        }
+        let updateRequest = `<contextmap><id>${this.id}</id><pageid>${pageId}</pageid><language>${this.language}</language></contextmap>`;
+        return this.plug.put(updateRequest, 'application/xml; charset=utf-8').then(contextMapModel.parse);
+    }
+    remove() {
+        return this.plug.delete();
+    }
+}
+export {ContextDefinition, ContextMap};

--- a/models/contextId.model.js
+++ b/models/contextId.model.js
@@ -1,0 +1,11 @@
+import modelHelper from './modelHelper';
+let contextIdModel = {
+    parse(data) {
+        let parsed = modelHelper.fromJson(data);
+        if('context' in parsed) {
+            parsed = parsed.context;
+        }
+        return parsed;
+    }
+};
+export default contextIdModel;

--- a/models/contextIds.model.js
+++ b/models/contextIds.model.js
@@ -1,0 +1,18 @@
+import modelHelper from './modelHelper';
+let contextIdsModel = {
+    parse(data) {
+        if(data === '') {
+            data = `{"context": []}`;
+        }
+        let obj = modelHelper.fromJson(data);
+        let parsed = {
+            context: []
+        };
+        let contexts = Array.isArray(obj.context) ? obj.context : [ obj.context ];
+        contexts.forEach((c) => {
+            parsed.context.push(c);
+        });
+        return parsed;
+    }
+};
+export default contextIdsModel;

--- a/models/contextMap.model.js
+++ b/models/contextMap.model.js
@@ -1,0 +1,23 @@
+import modelHelper from './modelHelper';
+import pageModel from './page.model';
+let contextMapModel = {
+    parse(data) {
+        let obj = modelHelper.fromJson(data);
+        let parsed = {
+            default: modelHelper.getBool(obj['@default']),
+            exists: modelHelper.getBool(obj['@exists']),
+            description: obj.description,
+            id: obj.id,
+            language: obj.language
+        };
+        if('page' in obj) {
+            parsed.page = pageModel.parse(obj.page);
+        }
+        if('pageid' in obj) {
+            let id = modelHelper.getString(obj.pageid);
+            parsed.pageId = parseInt(id, 10);
+        }
+        return parsed;
+    }
+};
+export default contextMapModel;

--- a/models/contextMaps.model.js
+++ b/models/contextMaps.model.js
@@ -1,0 +1,19 @@
+import modelHelper from './modelHelper';
+import contextMapModel from './contextMap.model';
+let contextMapsModel = {
+    parse(data) {
+        let obj = modelHelper.fromJson(data);
+        let parsed = {
+            contextMap: [],
+            languages: Array.isArray(obj.languages.language) ? obj.languages : [ obj.languages.language ]
+        };
+        if('contextmap' in obj) {
+            let maps = Array.isArray(obj.contextmap) ? obj.contextmap : [ obj.contextmap ];
+            maps.forEach((map) => {
+                parsed.contextMap.push(contextMapModel.parse(map));
+            });
+        }
+        return parsed;
+    }
+};
+export default contextMapsModel;

--- a/test/contextId.test.js
+++ b/test/contextId.test.js
@@ -1,0 +1,168 @@
+import {ContextDefinition, ContextMap} from 'contextId';
+describe('Context ID', () => {
+    beforeEach(() => {
+        jasmine.Ajax.install();
+    });
+    afterEach(() => {
+        jasmine.Ajax.uninstall();
+    });
+    describe('static functionality', () => {
+        let idsUri = '/@api/deki/contexts?';
+        it('can fetch the list of all definitions', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinitions });
+            ContextDefinition.getDefinitions().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fetch the list of all definitions (single)', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsSingle });
+            ContextDefinition.getDefinitions().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fetch the list of all definitions (empty)', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsEmpty });
+            ContextDefinition.getDefinitions().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can add a context ID definition', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsSingle });
+            ContextDefinition.addDefinition('foo').then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can add a context ID definition with a description', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsSingle });
+            ContextDefinition.addDefinition('foo', 'Foo description').then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fail if an ID is not supplied when trying to add a definition', (done) => {
+            ContextDefinition.addDefinition().catch((e) => {
+                expect(e.message).toBe('an ID must be supplied to add a definintion');
+                done();
+            });
+        });
+    });
+    describe('definition constructor', () => {
+        it('can create a new ContextDefinition', () => {
+            expect(() => new ContextDefinition()).toThrow();
+            let c = new ContextDefinition('foo');
+            expect(c).toBeDefined();
+            expect(() => ContextDefinition()).toThrow();
+        });
+    });
+    describe('definition instance functions', () => {
+        let def = null;
+        beforeEach(() => {
+            def = new ContextDefinition('foo');
+        });
+        afterEach(() => {
+            def = null;
+        });
+        let defUri = '/@api/deki/contexts/foo?';
+        it('can get the definition info', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinition });
+            def.getInfo().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can update the description of a definintion', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinition });
+            def.updateDescription('New Description').then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can implicitly clear the description of a definintion', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinition });
+            def.updateDescription().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can delete a definition', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'POST').andReturn({ status: 200 });
+            def.delete().then(() => {
+                done();
+            });
+        });
+    });
+    describe('context map static functionality', () => {
+        let mapsUri = '/@api/deki/contextmaps?';
+        it('can fetch all context maps', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(mapsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMaps });
+            ContextMap.getMaps().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fetch all context maps (single language)', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(mapsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMapsSingleLanguage });
+            ContextMap.getMaps().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+    });
+    describe('Context Map constructor', () => {
+        it('can construct a new Context Map', () => {
+            expect(() => ContextMap()).toThrow();
+            expect(() => new ContextMap()).toThrow();
+            expect(() => new ContextMap('foo')).toThrow();
+            let cm = new ContextMap('en-us', 'foo');
+            expect(cm).toBeDefined();
+        });
+    });
+    describe('ContextMap instance functions', () => {
+        let mapUri = '/@api/deki/contextmaps/en-us/foo?';
+        let map = null;
+        beforeEach(() => {
+            map = new ContextMap('en-us', 'foo');
+        });
+        afterEach(() => {
+            map = null;
+        });
+        it('can get the info of a map', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMap });
+            map.getInfo().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can get the verbose info of a map', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMapVerbose });
+            map.getInfo().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can update an existing map', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextMapVerbose });
+            map.update(123).then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fail if an ID is not supplied when updating a map', (done) => {
+            map.update().catch((e) => {
+                expect(e.message).toBe('a page ID must be supplied in order to update a mapping');
+                done();
+            });
+        });
+        it('can clear a mapping', (done) => {
+            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'POST').andReturn({ status: 200 });
+            map.remove().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+    });
+});

--- a/test/mock/contextId.mock.js
+++ b/test/mock/contextId.mock.js
@@ -1,0 +1,147 @@
+window.Mocks = window.Mocks || {};
+Mocks.contextIdDefinitions = `{
+    "context":[
+        {"description":"Foo description","id":"foo"},
+        {"description":"","id":"sdf"}
+    ]
+}`;
+Mocks.contextIdDefinitionsSingle = `{
+    "context":{"description":"","id":"foo"}
+}`;
+Mocks.contextIdDefinitionsEmpty = ``;
+Mocks.contextIdDefinition = `{"description":"Description of foo","id":"foo"}`;
+Mocks.contextMaps = `{
+    "contextmap":[
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"",
+            "id":"bar",
+            "language":"en-us",
+            "page":{
+                "@id":"336",
+                "@draft.state":"inactive",
+                "@href":"https://marsdev.mindtouch.dev/@api/deki/pages/336?redirects=0",
+                "@deleted":"false",
+                "date.created":"Mon, 23 Mar 2015 19:58:47 GMT",
+                "language":"en-US",
+                "namespace":"main",
+                "path":{"@seo":"true","#text":"Category_1"},
+                "title":"Category 1",
+                "uri.ui":"https://marsdev.mindtouch.dev/Category_1"
+            },
+            "pageid":{"@page-status":"included","#text":"336"}
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"",
+            "id":"bar",
+            "language":"pt-br"
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"",
+            "id":"dfsggf",
+            "language":"en-us"
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"",
+            "id":"dfsggf",
+            "language":"pt-br"
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"Foo Descriptiondddd",
+            "id":"foo",
+            "language":"en-us"
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"Foo Descriptiondddd",
+            "id":"foo",
+            "language":"pt-br"
+        }
+    ],
+    "languages":{
+        "language":["en-us","pt-br"]
+    }
+}`;
+Mocks.contextMapsSingleLanguage = `{
+    "contextmap":[
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"",
+            "id":"bar",
+            "language":"en-us",
+            "page":{
+                "@id":"336",
+                "@draft.state":"inactive",
+                "@href":"https://marsdev.mindtouch.dev/@api/deki/pages/336?redirects=0",
+                "@deleted":"false",
+                "date.created":"Mon, 23 Mar 2015 19:58:47 GMT",
+                "language":"en-US",
+                "namespace":"main",
+                "path":{"@seo":"true","#text":"Category_1"},
+                "title":"Category 1",
+                "uri.ui":"https://marsdev.mindtouch.dev/Category_1"
+            },
+            "pageid":{"@page-status":"included","#text":"336"}
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"",
+            "id":"dfsggf",
+            "language":"en-us"
+        },
+        {
+            "@default":"false",
+            "@exists":"true",
+            "description":"Foo Descriptiondddd",
+            "id":"foo",
+            "language":"en-us"
+        }
+    ],
+    "languages":{"language":"en-us"}
+}`;
+Mocks.contextMapSingleSingle = `{
+    "contextmap":{
+        "@default":"false",
+        "@exists":"true",
+        "description":"",
+        "id":"sdf",
+        "language":"en-us"
+    },
+    "languages":{"language":"en-us"}
+}`;
+Mocks.contextMapsEmptySingleLanguage = `{"languages":{"language":"en-us"}}`;
+Mocks.contextMapsEmpty = `{"languages":{"language":["en-us","pt-br"]}}`;
+Mocks.contextMap = `{"@default":"false","@exists":"true","description":"Foo Description","id":"foo","language":"en-us","pageid":"273"}`;
+Mocks.contextMapVerbose = `{
+    "@default":"false",
+    "@exists":"true",
+    "description":"Foo Description",
+    "id":"foo",
+    "language":"en-us",
+    "page":{
+        "@id":"336",
+        "@draft.state":"inactive",
+        "@href":"https://marsdev.mindtouch.dev/@api/deki/pages/336?redirects=0",
+        "@deleted":"false",
+        "@exists":"true",
+        "date.created":"Mon, 23 Mar 2015 19:58:47 GMT",
+        "language":"en-US",
+        "namespace":"main",
+        "path":{"@seo":"true","#text":"Category_1"},
+        "title":"Category 1",
+        "uri.ui":"https://marsdev.mindtouch.dev/Category_1"
+    },
+    "pageid":{"@page-status":"included","#text":"336"}
+}`;


### PR DESCRIPTION
Reviewed by @killsunday 

Add support for accessing and manipulating the Context ID subsystem of the MindTouch API.