### PR TITLE
Add support for previousScore API parameter in page rating

### DIFF
--- a/page.js
+++ b/page.js
@@ -87,12 +87,16 @@ export default class Page {
     getRating() {
         return this._plug.at('ratings').get().then(pageRatingModel.parse);
     }
-    rate(rating = '') {
+    rate(rating = '', oldRating = '') {
         rating = rating.toString();
+        oldRating = oldRating.toString();
         if(rating !== '1' && rating !== '0' && rating !== '') {
             throw new Error('Invalid rating supplied');
         }
-        return this._plug.at('ratings').withParams({ score: rating }).post(null, utility.textRequestType).then(pageRatingModel.parse);
+        if(oldRating !== '1' && oldRating !== '0' && oldRating !== '') {
+            throw new Error('Invalid rating supplied for the old rating');
+        }
+        return this._plug.at('ratings').withParams({ score: rating, previousScore: oldRating }).post(null, utility.textRequestType).then(pageRatingModel.parse);
     }
     logPageView() {
         var viewPlug = new Plug().at('@api', 'deki', 'events', 'page-view', this._id).withParam('uri', encodeURIComponent(document.location.href));

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -313,6 +313,9 @@ describe('Page', () => {
             expect(() => page.rate('foo')).toThrow();
             expect(() => page.rate(10)).toThrow();
             expect(() => page.rate({ score: 1 })).toThrow();
+            expect(() => page.rate(1, 'foo')).toThrow();
+            expect(() => page.rate(1, 10)).toThrow();
+            expect(() => page.rate(1, { score: 1 })).toThrow();
         });
         it('can fetch a template rendered in the context of the Page', (done) => {
             let contentsUri = '/@api/deki/pages/=Template%253AMindTouch%252FIDF3%252FControls%252FWelcomeMessage/contents?';


### PR DESCRIPTION
Reviewed by @modethirteen 

The page rating API now takes an optional parameter so the caller can inform the API of the previous score of the page.  This is especially when an anonymous user is rating a page.