### PR TITLE
Include request types for POSTs to the API

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -19,6 +19,9 @@
 import stringUtility from './stringUtility';
 import settings from '../settings';
 let utility = {
+    xmlRequestType: 'application/xml; charset=utf-8',
+    textRequestType: 'text/plain; charset=utf-8',
+    jsonRequestType: 'application/json; charset=utf-8',
     searchEscape: function(query) {
         let result = query.toString();
         let charArr = [ '\\', '+', '-', '&', '|', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':' ];


### PR DESCRIPTION
Reviewed by @modethirteen 

Add common MIME types for use with the MindTouch API.