### PR TITLE
Fix a lint warning and gulp based test runner

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,11 +27,11 @@ var inspectSources = [
 ];
 
 /*** js tests ***/
-gulp.task('test', function(done) {
+gulp.task('test', function() {
     new KarmaServer({
         configFile: __dirname + '/karma.conf.js',
         singleRun: true
-    }, done).start();
+    }).start();
 });
 
 /*** sub tasks ***/

--- a/models/draft.model.js
+++ b/models/draft.model.js
@@ -55,6 +55,6 @@ let draftModel = {
             parsed.userAuthor = userModel.parse(obj['user.author']);
         }
         return parsed;
-    },
+    }
 };
 export default draftModel;


### PR DESCRIPTION
The callback from the Karma server is not necessary at this point, and it is fine to leave it to its default behavior.
