### PR TITLE
Create static Plug objects on-demand

### DIFF
--- a/contextId.js
+++ b/contextId.js
@@ -3,24 +3,29 @@ import contextIdsModel from 'models/contextIds.model';
 import contextIdModel from 'models/contextId.model';
 import contextMapsModel from 'models/contextMaps.model';
 import contextMapModel from 'models/contextMap.model';
-let definitionsPlug = new Plug().at('@api', 'deki', 'contexts');
 class ContextDefinition {
+    static _getPlug() {
+        if(!this.definitionsPlug) {
+            this.definitionsPlug = new Plug().at('@api', 'deki', 'contexts');
+        }
+        return this.definitionsPlug;
+    }
     static getDefinitions() {
-        return definitionsPlug.get().then(contextIdsModel.parse);
+        return ContextDefinition._getPlug().get().then(contextIdsModel.parse);
     }
     static addDefinition(id, description = '') {
         if(!id) {
             return Promise.reject(new Error('an ID must be supplied to add a definintion'));
         }
         let addRequest = `<contexts><context><id>${id}</id><description>${description}</description></context></contexts>`;
-        return definitionsPlug.post(addRequest, 'application/xml; charset=utf-8').then(contextIdModel.parse);
+        return ContextDefinition._getPlug().post(addRequest, 'application/xml; charset=utf-8').then(contextIdModel.parse);
     }
     constructor(id) {
         if(!id) {
             throw new Error('an ID must be supplied to create a new ContextDefinition');
         }
         this.id = id;
-        this.plug = definitionsPlug.at(id);
+        this.plug = ContextDefinition._getPlug().at(id);
     }
     getInfo() {
         return this.plug.get().then(contextIdModel.parse);
@@ -33,10 +38,15 @@ class ContextDefinition {
         return this.plug.delete();
     }
 }
-let mapsPlug = new Plug().at('@api', 'deki', 'contextmaps').withParam('verbose', 'true');
 class ContextMap {
+    static _getPlug() {
+        if(!this.mapsPlug) {
+            this.mapsPlug = new Plug().at('@api', 'deki', 'contextmaps').withParam('verbose', 'true');
+        }
+        return this.mapsPlug;
+    }
     static getMaps() {
-        return mapsPlug.get().then(contextMapsModel.parse);
+        return ContextMap._getPlug().get().then(contextMapsModel.parse);
     }
     constructor(language, id) {
         if(!id || !language) {
@@ -44,7 +54,7 @@ class ContextMap {
         }
         this.id = id;
         this.language = language;
-        this.plug = mapsPlug.at(language, id);
+        this.plug = ContextMap._getPlug().at(language, id);
     }
     getInfo() {
         return this.plug.get().then(contextMapModel.parse);

--- a/site.js
+++ b/site.js
@@ -20,7 +20,6 @@ import utility from './lib/utility';
 import stringUtility from './lib/stringUtility';
 import Plug from './lib/plug';
 import SearchModel from './models/search.model';
-let sitePlug = new Plug().at('@api', 'deki', 'site');
 function _buildSearchConstraints(params) {
     let constraints = [];
     params.namespace = 'main';
@@ -44,11 +43,17 @@ function _buildSearchConstraints(params) {
     return '+(' + constraints.join(' ') + ')';
 }
 export default class Site {
+    static _getPlug() {
+        if(!this.sitePlug) {
+            this.sitePlug = new Plug().at('@api', 'deki', 'site');
+        }
+        return this.sitePlug;
+    }
     static getResourceString(options = {}) {
         if(!('key' in options)) {
             return Promise.reject('No resource key was supplied');
         }
-        let locPlug = sitePlug.at('localization', options.key);
+        let locPlug = Site._getPlug().at('localization', options.key);
         if('lang' in options) {
             locPlug = locPlug.withParam('lang', options.lang);
         }
@@ -71,7 +76,7 @@ export default class Site {
             summarypath: encodeURI(path),
             constraint: _buildSearchConstraints(constraint)
         };
-        return sitePlug.at('query').withParams(searchParams).get().then((res) => {
+        return Site._getPlug().at('query').withParams(searchParams).get().then((res) => {
             return SearchModel.parse(res);
         });
     }

--- a/user.js
+++ b/user.js
@@ -20,8 +20,13 @@ import Plug from './lib/plug';
 import utility from './lib/utility';
 import userModel from './models/user.model';
 import userListModel from './models/userList.model';
-let userPlug = new Plug().at('@api', 'deki', 'users');
 export default class User {
+    static _getPlug() {
+        if(!this.userPlug) {
+            this.userPlug = new Plug().at('@api', 'deki', 'users');
+        }
+        return this.userPlug;
+    }
     static getCurrentUser() {
         return userPlug.at('current').get().then(userModel.parse);
     }

--- a/user.js
+++ b/user.js
@@ -28,17 +28,17 @@ export default class User {
         return this.userPlug;
     }
     static getCurrentUser() {
-        return userPlug.at('current').get().then(userModel.parse);
+        return User._getPlug().at('current').get().then(userModel.parse);
     }
     static getUsers() {
-        return userPlug.get().then(userListModel.parse);
+        return User._getPlug().get().then(userListModel.parse);
     }
     static searchUsers(constraints) {
-        return userPlug.at('search').withParams(constraints).get().then(userListModel.parse);
+        return User._getPlug().at('search').withParams(constraints).get().then(userListModel.parse);
     }
     constructor(id = 'current') {
         this._id = utility.getResourceId(id, 'current');
-        this._plug = userPlug.at(this._id);
+        this._plug = User._getPlug().at(this._id);
     }
     getInfo() {
         return this._plug.get().then(userModel.parse);


### PR DESCRIPTION
Reviewed by @killsunday 

This moves a few Plug construction lines to static functionality.  By moving them, they are created on-demand, rather immediately at module load time.

This is necessary because martian needs to be loaded before it is configured.  The Plug objects can't be created until after the external configuration occurs as the calling code might need to set the host name in martian settings.