### PR TITLE
Make JSON failures less browser-dependent

### DIFF
--- a/test/groups.test.js
+++ b/test/groups.test.js
@@ -57,7 +57,7 @@ describe('Group API', () => {
         it('can handle invalid JSON when fetching the groups', (done) => {
             jasmine.Ajax.stubRequest(new RegExp(groupsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             Group.getGroupList().catch((e) => {
-                expect(e.message).toBe('Unable to parse JSON string');
+                expect(e.message).toBeDefined();
                 done();
             });
         });

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -70,7 +70,7 @@ describe('Page', () => {
             jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             page.getInfo().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse JSON string');
+                expect(r.message).toBeDefined();
                 done();
             });
         });
@@ -122,7 +122,7 @@ describe('Page', () => {
             jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             page.getFullInfo().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse JSON string');
+                expect(r.message).toBeDefined();
                 done();
             });
         });
@@ -155,7 +155,7 @@ describe('Page', () => {
             jasmine.Ajax.stubRequest(new RegExp(subpagesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             page.getSubpages().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse JSON string');
+                expect(r.message).toBeDefined();
                 done();
             });
         });
@@ -180,7 +180,7 @@ describe('Page', () => {
             jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             page.getContents().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse JSON string');
+                expect(r.message).toBeDefined();
                 done();
             });
         });
@@ -197,7 +197,7 @@ describe('Page', () => {
             jasmine.Ajax.stubRequest(new RegExp(treeUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             page.getTree().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse JSON string');
+                expect(r.message).toBeDefined();
                 done();
             });
         });
@@ -244,7 +244,7 @@ describe('Page', () => {
             jasmine.Ajax.stubRequest(new RegExp(tagsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
             page.getTags().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse JSON string');
+                expect(r.message).toBeDefined();
                 done();
             });
         });


### PR DESCRIPTION
The JSON parsing failures in the unit tests were expecting browser-specific error strings.  This won't work if we ever ditch Phantom for something else (stay tuned)