### PR TITLE
allow cors credentials

### DIFF
--- a/lib/plug.js
+++ b/lib/plug.js
@@ -36,6 +36,9 @@ function _getText(xhr) {
 function _doRequest(params) {
     return new Promise((resolve, reject) => {
         let xhr = new XMLHttpRequest();
+        
+        // server will only respond with Access-Control-Allow-Credentials if valid developer token is provided
+        xhr.withCredentials = true;
         let requestParams = {
             _: Date.now(),
             origin: 'mt-web' // TODO: F1 req from settings module after 20150820


### PR DESCRIPTION
@aaronmars since the server needs a token to provide Access-Control-Allow-Credentials, and our cookies are http only (no javascript access) this is safe to do, and required for CORS.