### PR TITLE
Refactor martian to allow Settings on a per-object basis

### DIFF
--- a/contextId.js
+++ b/contextId.js
@@ -1,31 +1,15 @@
-import Plug from './lib/plug';
-import contextIdsModel from 'models/contextIds.model';
-import contextIdModel from 'models/contextId.model';
-import contextMapsModel from 'models/contextMaps.model';
-import contextMapModel from 'models/contextMap.model';
-class ContextDefinition {
-    static _getPlug() {
-        if(!this.definitionsPlug) {
-            this.definitionsPlug = new Plug().at('@api', 'deki', 'contexts');
-        }
-        return this.definitionsPlug;
-    }
-    static getDefinitions() {
-        return ContextDefinition._getPlug().get().then(contextIdsModel.parse);
-    }
-    static addDefinition(id, description = '') {
-        if(!id) {
-            return Promise.reject(new Error('an ID must be supplied to add a definintion'));
-        }
-        let addRequest = `<contexts><context><id>${id}</id><description>${description}</description></context></contexts>`;
-        return ContextDefinition._getPlug().post(addRequest, 'application/xml; charset=utf-8').then(contextIdModel.parse);
-    }
-    constructor(id) {
+import {Plug} from './lib/plug';
+import {contextIdsModel} from 'models/contextIds.model';
+import {contextIdModel} from 'models/contextId.model';
+import {contextMapsModel} from 'models/contextMaps.model';
+import {contextMapModel} from 'models/contextMap.model';
+export class ContextDefinition {
+    constructor(id, settings) {
         if(!id) {
             throw new Error('an ID must be supplied to create a new ContextDefinition');
         }
         this.id = id;
-        this.plug = ContextDefinition._getPlug().at(id);
+        this.plug = new Plug(settings).at('@api', 'deki', 'contexts', id);
     }
     getInfo() {
         return this.plug.get().then(contextIdModel.parse);
@@ -38,23 +22,14 @@ class ContextDefinition {
         return this.plug.delete();
     }
 }
-class ContextMap {
-    static _getPlug() {
-        if(!this.mapsPlug) {
-            this.mapsPlug = new Plug().at('@api', 'deki', 'contextmaps').withParam('verbose', 'true');
-        }
-        return this.mapsPlug;
-    }
-    static getMaps() {
-        return ContextMap._getPlug().get().then(contextMapsModel.parse);
-    }
-    constructor(language, id) {
+export class ContextMap {
+    constructor(language, id, settings) {
         if(!id || !language) {
             throw new Error('an ID and language must be supplied to create a new ContextMap');
         }
         this.id = id;
         this.language = language;
-        this.plug = ContextMap._getPlug().at(language, id);
+        this.plug = new Plug(settings).at('@api', 'deki', 'contextmaps', language, id).withParam('verbose', 'true');
     }
     getInfo() {
         return this.plug.get().then(contextMapModel.parse);
@@ -70,4 +45,29 @@ class ContextMap {
         return this.plug.delete();
     }
 }
-export {ContextDefinition, ContextMap};
+export class ContextIdManager {
+    constructor(settings) {
+        this.mapsPlug = new Plug(settings).at('@api', 'deki', 'contextmaps').withParam('verbose', 'true');
+        this.definitionsPlug = new Plug(settings).at('@api', 'deki', 'contexts');
+        this.settings = settings;
+    }
+    getMaps() {
+        return this.mapsPlug.get().then(contextMapsModel.parse);
+    }
+    getDefinitions() {
+        return this.definitionsPlug.get().then(contextIdsModel.parse);
+    }
+    addDefinition(id, description = '') {
+        if(!id) {
+            return Promise.reject(new Error('an ID must be supplied to add a definintion'));
+        }
+        let addRequest = `<contexts><context><id>${id}</id><description>${description}</description></context></contexts>`;
+        return this.definitionsPlug.post(addRequest, 'application/xml; charset=utf-8').then(contextIdModel.parse);
+    }
+    getDefinition(id) {
+        return new ContextDefinition(id, this.settings);
+    }
+    getMap(language, id) {
+        return new ContextMap(language, id, this.settings);
+    }
+}

--- a/draft.js
+++ b/draft.js
@@ -16,13 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import PagePro from './page.pro';
-import draftModel from './models/draft.model';
-export default class Draft extends PagePro {
-    constructor(id = 'home') {
-        super(id);
-        this._plug = new Plug().at('@api', 'deki', 'drafts', this._id);
+import {Plug} from './lib/plug';
+import {PagePro} from './page.pro';
+import {draftModel} from './models/draft.model';
+export class Draft extends PagePro {
+    constructor(id = 'home', settings) {
+        super(id, settings);
+        this._plug = new Plug(settings).at('@api', 'deki', 'drafts', this._id);
     }
     getFullInfo() {
         return this._plug.get().then(draftModel.parse);

--- a/feedback.js
+++ b/feedback.js
@@ -16,12 +16,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import utility from './lib/utility';
-import stringUtility from './lib/stringUtility';
-import pageRatingsModel from './models/pageRatings.model';
-let feedback = {
-    submit: function(options) {
+import {Plug} from './lib/plug';
+import {utility} from './lib/utility';
+import {stringUtility} from './lib/stringUtility';
+import {pageRatingsModel} from './models/pageRatings.model';
+export class FeedbackManager {
+    constructor(settings) {
+        this.plug = new Plug(settings).at('@api', 'deki');
+    }
+    submit(options) {
         let path = options.path || stringUtility.leftTrim(window.location.pathname, '/');
         let request = JSON.stringify({
             _path: encodeURIComponent(path),
@@ -31,12 +34,11 @@ let feedback = {
             content: options.content,
             contactAllowed: options.contactAllowed
         });
-        let plug = new Plug().at('@api', 'deki', 'workflow', 'submit-feedback');
+        let plug = this.plug.at('workflow', 'submit-feedback');
         return plug.post(request, utility.jsonRequestType);
-    },
-    getRatingsForPages: function(pageIds) {
-        var ratingsPlug = new Plug().at('@api', 'deki', 'pages', 'ratings').withParams({ pageids: pageIds.join(',') });
+    }
+    getRatingsForPages(pageIds) {
+        var ratingsPlug = this.plug.at('pages', 'ratings').withParams({ pageids: pageIds.join(',') });
         return ratingsPlug.get().then(pageRatingsModel.parse);
     }
-};
-export default feedback;
+}

--- a/file.js
+++ b/file.js
@@ -16,13 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import utility from './lib/utility';
-import fileModel from './models/file.model';
-import fileRevisionsModel from './models/fileRevisions.model';
-export default class File {
-    constructor(id) {
-        this._plug = new Plug().at('@api', 'deki', 'files', id).withParam('draft', true);
+import {Plug} from './lib/plug';
+import {utility} from './lib/utility';
+import {fileModel} from './models/file.model';
+import {fileRevisionsModel} from './models/fileRevisions.model';
+export class File {
+    constructor(id, settings) {
+        this._plug = new Plug(settings).at('@api', 'deki', 'files', id).withParam('draft', true);
     }
     getInfo() {
         return this._plug.at('info').get().then(fileModel.parse);

--- a/group.js
+++ b/group.js
@@ -16,27 +16,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import utility from './lib/utility';
-import groupModel from 'models/group.model';
-import groupListModel from 'models/groupList.model';
-import userListModel from 'models/userList.model';
-export default class Group {
-    static getGroupList() {
-        var plug = new Plug().at('@api', 'deki', 'groups');
-        return plug.get().then(groupListModel.parse);
-    }
-    constructor(id) {
+import {Plug} from './lib/plug';
+import {utility} from './lib/utility';
+import {groupModel} from 'models/group.model';
+import {groupListModel} from 'models/groupList.model';
+import {userListModel} from 'models/userList.model';
+export class Group {
+    constructor(id, settings) {
         if(!id) {
             throw new Error('A group ID must be supplied');
         }
         this._id = utility.getResourceId(id);
-        this._groupPlug = new Plug().at('@api', 'deki', 'groups', this._id);
+        this._groupPlug = new Plug(settings).at('@api', 'deki', 'groups', this._id);
     }
     getInfo() {
         return this._groupPlug.get().then(groupModel.parse);
     }
     getUsers(options) {
         return this._groupPlug.at('users').withParams(options).get().then(userListModel.parse);
+    }
+}
+export class GroupManager {
+    constructor(settings) {
+        this.plug = new Plug(settings).at('@api', 'deki', 'groups');
+        this.settings = settings;
+    }
+    getGroupList() {
+        return this.plug.get().then(groupListModel.parse);
+    }
+    getGroup(id) {
+        return new Group(id, this.settings);
     }
 }

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import settings from './settings';
-import Uri from './uri';
+import {Settings} from './settings';
+import {Uri} from './uri';
 import XhrError from '../errors/xhrError';
 function _handleHttpError(xhr) {
     return new Promise((resolve, reject) => {
@@ -71,8 +71,17 @@ function _doRequest(params) {
         }
     });
 }
-export default class Plug {
-    constructor(url = settings.get('host'), params = {}) {
+export class Plug {
+    constructor(settings = null, params = {}) {
+        let url = '';
+        let token = null;
+        if(!settings) {
+            this.settings = new Settings({});
+        } else {
+            url = settings.get('host');
+            token = settings.get('token');
+            this.settings = settings;
+        }
 
         // initailize the url for this instance
         let _url = new Uri(url);
@@ -94,7 +103,6 @@ export default class Plug {
         }
         this.url = _url;
         this.headers = params.headers || {};
-        let token = settings.get('token');
         if(token && token !== '') {
             this.headers['X-Deki-Token'] = token;
         }
@@ -112,7 +120,8 @@ export default class Plug {
         segments.forEach(function(segment) {
             values.push(segment.toString());
         });
-        return new Plug(this.url.toString(), {
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, {
             headers: this.headers,
             constructionParams: { segments: segments }
         });
@@ -120,22 +129,22 @@ export default class Plug {
     withParam(key, value) {
         let params = {};
         params[key] = value;
-        return new Plug(this.url.toString(), {
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, {
             headers: this.headers,
             constructionParams: { query: params }
         });
     }
-    withParams(values) {
-        if(!values) {
-            values = {};
-        }
-        return new Plug(this.url.toString(), {
+    withParams(values = {}) {
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, {
             headers: this.headers,
             constructionParams: { query: values }
         });
     }
     withoutParam(key) {
-        return new Plug(this.url.toString(), {
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, {
             headers: this.headers,
             constructionParams: { excludeQuery: key }
         });
@@ -150,19 +159,22 @@ export default class Plug {
     withHeader(key, value) {
         let newHeaders = this._copyHeaders();
         newHeaders[key] = value;
-        return new Plug(this.url.toString(), { headers: newHeaders });
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, { headers: newHeaders });
     }
     withHeaders(values) {
         let newHeaders = this._copyHeaders();
         Object.keys(values).forEach((key) => {
             newHeaders[key] = values[key];
         });
-        return new Plug(this.url.toString(), { headers: newHeaders });
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, { headers: newHeaders });
     }
     withoutHeader(key) {
         let newHeaders = this._copyHeaders();
         delete newHeaders[key];
-        return new Plug(this.url.toString(), { headers: newHeaders });
+        let newSettings = this.settings.clone({ host: this.url.toString() });
+        return new Plug(newSettings, { headers: newHeaders });
     }
     get(verb = 'GET') {
         return this.getRaw(verb).then(_handleHttpError).then(_getText);

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -19,6 +19,20 @@
 import {Settings} from './settings';
 import {Uri} from './uri';
 import XhrError from '../errors/xhrError';
+function _getSettings(settings) {
+    if(settings) {
+
+        // First, return settings that were supplied
+        return settings;
+    } else if(window.MartianSettings) {
+
+        // Fall back to a global settings defined for the whole page
+        return window.MartianSettings;
+    }
+
+    // Default to an empty, blank Settings object
+    return new Settings();
+}
 function _handleHttpError(xhr) {
     return new Promise((resolve, reject) => {
 
@@ -75,13 +89,11 @@ export class Plug {
     constructor(settings = null, params = {}) {
         let url = '';
         let token = null;
-        if(!settings) {
-            this.settings = new Settings({});
-        } else {
-            url = settings.get('host');
-            token = settings.get('token');
-            this.settings = settings;
-        }
+
+        // Initialize the settings
+        this.settings = _getSettings(settings);
+        url = this.settings.get('host');
+        token = this.settings.get('token');
 
         // initailize the url for this instance
         let _url = new Uri(url);

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -21,16 +21,11 @@ import {Uri} from './uri';
 import XhrError from '../errors/xhrError';
 function _getSettings(settings) {
     if(settings) {
-
-        // First, return settings that were supplied
         return settings;
-    } else if(window.MartianSettings) {
-
-        // Fall back to a global settings defined for the whole page
-        return window.MartianSettings;
     }
 
-    // Default to an empty, blank Settings object
+    // If a settings object wasn't supplied, fall back to a default settings
+    //  object that may have some pre-applied default config.
     return new Settings();
 }
 function _handleHttpError(xhr) {

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -19,15 +19,6 @@
 import {Settings} from './settings';
 import {Uri} from './uri';
 import XhrError from '../errors/xhrError';
-function _getSettings(settings) {
-    if(settings) {
-        return settings;
-    }
-
-    // If a settings object wasn't supplied, fall back to a default settings
-    //  object that may have some pre-applied default config.
-    return new Settings();
-}
 function _handleHttpError(xhr) {
     return new Promise((resolve, reject) => {
 
@@ -81,12 +72,12 @@ function _doRequest(params) {
     });
 }
 export class Plug {
-    constructor(settings = null, params = {}) {
+    constructor(settings = new Settings(), params = {}) {
         let url = '';
         let token = null;
 
         // Initialize the settings
-        this.settings = _getSettings(settings);
+        this.settings = settings;
         url = this.settings.get('host');
         token = this.settings.get('token');
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -16,18 +16,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-let properties = {
-    host: ''
-};
-let settings = {
-    get(propertyName) {
-        return properties[propertyName];
-    },
-    set(propertyName, value) {
-        properties[propertyName] = value;
-    },
-    getSettings() {
-        return properties;
+export class Settings {
+    constructor(properties = {}) {
+        this.properties = properties;
     }
-};
-export default settings;
+    clone(overrides = {}) {
+        let newProps = overrides;
+        Object.keys(this.properties).forEach((key) => {
+            if(!(key in overrides)) {
+                newProps[key] = this.properties[key];
+            }
+        });
+        return new Settings(newProps);
+    }
+    get(propertyName) {
+        return this.properties[propertyName];
+    }
+    set(propertyName, value) {
+        this.properties[propertyName] = value;
+    }
+    getSettings() {
+        return this.properties;
+    }
+}

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -16,8 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+let _defaultProperties = {};
 export class Settings {
-    constructor(properties = {}) {
+    static set defaults(properties) {
+        _defaultProperties = properties;
+    }
+    constructor(properties = _defaultProperties) {
         this.properties = properties;
     }
     clone(overrides = {}) {
@@ -35,7 +39,7 @@ export class Settings {
     set(propertyName, value) {
         this.properties[propertyName] = value;
     }
-    getSettings() {
+    getProperties() {
         return this.properties;
     }
 }

--- a/lib/stringUtility.js
+++ b/lib/stringUtility.js
@@ -57,4 +57,4 @@ let stringUtility = {
         return str.split(delimiter);
     }
 };
-export default stringUtility;
+export {stringUtility};

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 import {UriParser} from './uriParser';
-import stringUtility from './stringUtility';
-export default class Uri {
+import {stringUtility} from './stringUtility';
+export class Uri {
     constructor(url = '') {
         this.parsedUrl = new UriParser(url);
     }

--- a/lib/uriParser.js
+++ b/lib/uriParser.js
@@ -17,7 +17,7 @@ function _searchStringToParams(search) {
     });
     return params;
 }
-class UriSearchParams {
+export class UriSearchParams {
     constructor(searchString) {
         this.params = [];
         if(searchString && searchString !== '') {
@@ -91,7 +91,7 @@ class UriSearchParams {
         }, '');
     }
 }
-class UriParser {
+export class UriParser {
     constructor(urlString = '') {
         if(typeof urlString !== 'string') {
             throw new TypeError('Failed to construct \'URL\': The supplied URL must be a string');
@@ -216,4 +216,3 @@ class UriParser {
         return hrefString;
     }
 }
-export {UriParser, UriSearchParams};

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -39,4 +39,4 @@ let utility = {
         return resourceId;
     }
 };
-export default utility;
+export {utility};

--- a/models/contextId.model.js
+++ b/models/contextId.model.js
@@ -1,4 +1,4 @@
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let contextIdModel = {
     parse(data) {
         let parsed = modelHelper.fromJson(data);
@@ -8,4 +8,4 @@ let contextIdModel = {
         return parsed;
     }
 };
-export default contextIdModel;
+export {contextIdModel};

--- a/models/contextIds.model.js
+++ b/models/contextIds.model.js
@@ -1,4 +1,4 @@
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let contextIdsModel = {
     parse(data) {
         if(data === '') {
@@ -15,4 +15,4 @@ let contextIdsModel = {
         return parsed;
     }
 };
-export default contextIdsModel;
+export {contextIdsModel};

--- a/models/contextMap.model.js
+++ b/models/contextMap.model.js
@@ -1,5 +1,5 @@
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
 let contextMapModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -20,4 +20,4 @@ let contextMapModel = {
         return parsed;
     }
 };
-export default contextMapModel;
+export {contextMapModel};

--- a/models/contextMaps.model.js
+++ b/models/contextMaps.model.js
@@ -1,5 +1,5 @@
-import modelHelper from './modelHelper';
-import contextMapModel from './contextMap.model';
+import {modelHelper} from './modelHelper';
+import {contextMapModel} from './contextMap.model';
 let contextMapsModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -16,4 +16,4 @@ let contextMapsModel = {
         return parsed;
     }
 };
-export default contextMapsModel;
+export {contextMapsModel};

--- a/models/draft.model.js
+++ b/models/draft.model.js
@@ -16,9 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
-import userModel from './user.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
+import {userModel} from './user.model';
 let draftModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -57,4 +57,4 @@ let draftModel = {
         return parsed;
     }
 };
-export default draftModel;
+export {draftModel};

--- a/models/file.model.js
+++ b/models/file.model.js
@@ -16,9 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import userModel from './user.model';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {userModel} from './user.model';
+import {pageModel} from './page.model';
 let fileModel = {
     parse: (data) => {
         let obj = modelHelper.fromJson(data);
@@ -49,4 +49,4 @@ let fileModel = {
         return parsed;
     }
 };
-export default fileModel;
+export {fileModel};

--- a/models/fileRevisions.model.js
+++ b/models/fileRevisions.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import fileModel from './file.model';
+import {modelHelper} from './modelHelper';
+import {fileModel} from './file.model';
 let fileRevisionsModel = {
     parse: (data) => {
         let obj = modelHelper.fromJson(data);
@@ -36,4 +36,4 @@ let fileRevisionsModel = {
         return parsed;
     }
 };
-export default fileRevisionsModel;
+export {fileRevisionsModel};

--- a/models/group.model.js
+++ b/models/group.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let groupModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -27,4 +27,4 @@ let groupModel = {
         };
     }
 };
-export default groupModel;
+export {groupModel};

--- a/models/groupList.model.js
+++ b/models/groupList.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import groupModel from './group.model';
+import {modelHelper} from './modelHelper';
+import {groupModel} from './group.model';
 let groupListModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -37,4 +37,4 @@ let groupListModel = {
         return parsed;
     }
 };
-export default groupListModel;
+export {groupListModel};

--- a/models/modelHelper.js
+++ b/models/modelHelper.js
@@ -44,4 +44,4 @@ let modelHelper = {
         }
     }
 };
-export default modelHelper;
+export {modelHelper};

--- a/models/page.model.js
+++ b/models/page.model.js
@@ -16,9 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageRatingModel from './pageRating.model';
-import userModel from './user.model';
+import {modelHelper} from './modelHelper';
+import {pageRatingModel} from './pageRating.model';
+import {userModel} from './user.model';
 let pageModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -80,4 +80,4 @@ let pageModel = {
         return parsed;
     }
 };
-export default pageModel;
+export {pageModel};

--- a/models/pageContents.model.js
+++ b/models/pageContents.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let pageContentsModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -49,4 +49,4 @@ let pageContentsModel = {
         return targets;
     }
 };
-export default pageContentsModel;
+export {pageContentsModel};

--- a/models/pageEdit.model.js
+++ b/models/pageEdit.model.js
@@ -1,6 +1,6 @@
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
-import draftModel from './draft.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
+import {draftModel} from './draft.model';
 let pageEditModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -22,4 +22,4 @@ let pageEditModel = {
         return parsed;
     }
 };
-export default pageEditModel;
+export {pageEditModel};

--- a/models/pageFiles.model.js
+++ b/models/pageFiles.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import fileModel from './file.model';
+import {modelHelper} from './modelHelper';
+import {fileModel} from './file.model';
 let pageFilesModel = {
     parse: function(data) {
         let obj = modelHelper.fromJson(data);
@@ -37,4 +37,4 @@ let pageFilesModel = {
         return parsed;
     }
 };
-export default pageFilesModel;
+export {pageFilesModel};

--- a/models/pageMove.model.js
+++ b/models/pageMove.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
 let pageMoveModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -34,4 +34,4 @@ let pageMoveModel = {
         return parsed;
     }
 };
-export default pageMoveModel;
+export {pageMoveModel};

--- a/models/pageProperties.model.js
+++ b/models/pageProperties.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pagePropertyModel from './pageProperty.model';
+import {modelHelper} from './modelHelper';
+import {pagePropertyModel} from './pageProperty.model';
 let pagePropertiesModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -37,4 +37,4 @@ let pagePropertiesModel = {
         return parsed;
     }
 };
-export default pagePropertiesModel;
+export {pagePropertiesModel};

--- a/models/pageProperty.model.js
+++ b/models/pageProperty.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
 let pagePropertyModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -31,4 +31,4 @@ let pagePropertyModel = {
         return parsed;
     }
 };
-export default pagePropertyModel;
+export {pagePropertyModel};

--- a/models/pageRating.model.js
+++ b/models/pageRating.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let pageRatingModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -57,4 +57,4 @@ let pageRatingModel = {
         return parsed;
     }
 };
-export default pageRatingModel;
+export {pageRatingModel};

--- a/models/pageRatings.model.js
+++ b/models/pageRatings.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
 let pageRatingsModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -35,4 +35,4 @@ let pageRatingsModel = {
         return parsed;
     }
 };
-export default pageRatingsModel;
+export {pageRatingsModel};

--- a/models/pageTags.model.js
+++ b/models/pageTags.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let pageTagsModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -41,4 +41,4 @@ let pageTagsModel = {
         return parsed;
     }
 };
-export default pageTagsModel;
+export {pageTagsModel};

--- a/models/pageTree.model.js
+++ b/models/pageTree.model.js
@@ -16,12 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
 let pageTreeModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
         return pageModel.parse(obj.page);
     }
 };
-export default pageTreeModel;
+export {pageTreeModel};

--- a/models/search.model.js
+++ b/models/search.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let searchModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -53,4 +53,4 @@ let searchModel = {
         return search;
     }
 };
-export default searchModel;
+export {searchModel};

--- a/models/subpages.model.js
+++ b/models/subpages.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
+import {modelHelper} from './modelHelper';
 let subpagesModel = {
     parse(data) {
         let obj = modelHelper.fromJson(data);
@@ -46,4 +46,4 @@ let subpagesModel = {
         return parsed;
     }
 };
-export default subpagesModel;
+export {subpagesModel};

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import modelHelper from './modelHelper';
-import pageModel from './page.model';
+import {modelHelper} from './modelHelper';
+import {pageModel} from './page.model';
 let userModel = {
     parse: function(data) {
         let obj = modelHelper.fromJson(data);
@@ -40,4 +40,4 @@ let userModel = {
         return parsed;
     }
 };
-export default userModel;
+export {userModel};

--- a/models/userList.model.js
+++ b/models/userList.model.js
@@ -1,5 +1,5 @@
-import modelHelper from './modelHelper';
-import userModel from './user.model';
+import {modelHelper} from './modelHelper';
+import {userModel} from './user.model';
 let userListModel = {
     parse: (data) => {
         let obj = modelHelper.fromJson(data);
@@ -19,4 +19,4 @@ let userListModel = {
         return parsed;
     }
 };
-export default userListModel;
+export {userListModel};

--- a/page.js
+++ b/page.js
@@ -16,26 +16,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import modelHelper from './models/modelHelper';
-import pageModel from './models/page.model';
-import subpagesModel from './models/subpages.model';
-import pageContentsModel from './models/pageContents.model';
-import pageTreeModel from './models/pageTree.model';
-import pageTagsModel from './models/pageTags.model';
-import pageRatingModel from './models/pageRating.model';
-import pageFilesModel from './models/pageFiles.model';
-import utility from './lib/utility';
+import {Plug} from './lib/plug';
+import {modelHelper} from './models/modelHelper';
+import {pageModel} from './models/page.model';
+import {subpagesModel} from './models/subpages.model';
+import {pageContentsModel} from './models/pageContents.model';
+import {pageTreeModel} from './models/pageTree.model';
+import {pageTagsModel} from './models/pageTags.model';
+import {pageRatingModel} from './models/pageRating.model';
+import {pageFilesModel} from './models/pageFiles.model';
+import {utility} from './lib/utility';
 function _handleVirtualPage(error) {
     if(error.errorCode === 404 && error.response && error.response['@virtual']) {
         return Promise.resolve(pageModel.parse(error.response));
     }
     throw error;
 }
-export default class Page {
-    constructor(id = 'home') {
+export class Page {
+    constructor(id = 'home', settings) {
         this._id = utility.getResourceId(id, 'home');
-        this._plug = new Plug().at('@api', 'deki', 'pages', this._id);
+        this._plug = new Plug(settings).at('@api', 'deki', 'pages', this._id);
     }
     getInfo(params = {}) {
         let infoParams = { exclude: 'revision' };

--- a/page.pro.js
+++ b/page.pro.js
@@ -16,12 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Page from './page';
-import pageMoveModel from './models/pageMove.model';
-import pageEditModel from './models/pageEdit.model';
-export default class PagePro extends Page {
-    constructor(id = 'home') {
-        super(id);
+import {Page} from './page';
+import {pageMoveModel} from './models/pageMove.model';
+import {pageEditModel} from './models/pageEdit.model';
+export class PagePro extends Page {
+    constructor(id = 'home', settings) {
+        super(id, settings);
     }
     setOverview(options = {}) {
         if(!('body' in options)) {

--- a/pageHierarchy.js
+++ b/pageHierarchy.js
@@ -16,13 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import pageModel from './models/page.model';
-import subpagesModel from './models/subpages.model';
-export default class PageHierarchy {
-    constructor(articleTypes = []) {
+import {Plug} from './lib/plug';
+import {pageModel} from './models/page.model';
+import {subpagesModel} from './models/subpages.model';
+export class PageHierarchy {
+    constructor(articleTypes = [], settings) {
         this.filterByArticleTypes = articleTypes;
-        this._plug = new Plug().at('@api', 'deki', 'pages');
+        this._plug = new Plug(settings).at('@api', 'deki', 'pages');
     }
     getRoot(id = 'home') {
         return this._plug.at(id).get().then(pageModel.parse);

--- a/pageProperty.js
+++ b/pageProperty.js
@@ -16,14 +16,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import utility from './lib/utility';
-import pagePropertiesModel from './models/pageProperties.model';
-import pagePropertyModel from './models/pageProperty.model';
-export default class PageProperty {
-    constructor(id = 'home') {
+import {Plug} from './lib/plug';
+import {utility} from './lib/utility';
+import {pagePropertiesModel} from './models/pageProperties.model';
+import {pagePropertyModel} from './models/pageProperty.model';
+export class PageProperty {
+    constructor(id = 'home', settings) {
         this._id = utility.getResourceId(id, 'home');
-        this._plug = new Plug().at('@api', 'deki', 'pages', this._id, 'properties');
+        this._plug = new Plug(settings).at('@api', 'deki', 'pages', this._id, 'properties');
     }
     getProperties(names = []) {
         if(!Array.isArray(names)) {

--- a/site.js
+++ b/site.js
@@ -42,14 +42,7 @@ function _buildSearchConstraints(params) {
     }
     return '+(' + constraints.join(' ') + ')';
 }
-export class SiteManager {
-
-    /*static _getPlug(settings) {
-        if(!this.sitePlug) {
-            this.sitePlug = new Plug(settings).at('@api', 'deki', 'site');
-        }
-        return this.sitePlug;
-    }*/
+export class Site {
     constructor(settings) {
         this.plug = new Plug(settings).at('@api', 'deki', 'site');
     }

--- a/site.js
+++ b/site.js
@@ -16,10 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import utility from './lib/utility';
-import stringUtility from './lib/stringUtility';
-import Plug from './lib/plug';
-import SearchModel from './models/search.model';
+import {utility} from './lib/utility';
+import {stringUtility} from './lib/stringUtility';
+import {Plug} from './lib/plug';
+import {searchModel} from './models/search.model';
 function _buildSearchConstraints(params) {
     let constraints = [];
     params.namespace = 'main';
@@ -42,24 +42,28 @@ function _buildSearchConstraints(params) {
     }
     return '+(' + constraints.join(' ') + ')';
 }
-export default class Site {
-    static _getPlug() {
+export class SiteManager {
+
+    /*static _getPlug(settings) {
         if(!this.sitePlug) {
-            this.sitePlug = new Plug().at('@api', 'deki', 'site');
+            this.sitePlug = new Plug(settings).at('@api', 'deki', 'site');
         }
         return this.sitePlug;
+    }*/
+    constructor(settings) {
+        this.plug = new Plug(settings).at('@api', 'deki', 'site');
     }
-    static getResourceString(options = {}) {
+    getResourceString(options = {}) {
         if(!('key' in options)) {
             return Promise.reject('No resource key was supplied');
         }
-        let locPlug = Site._getPlug().at('localization', options.key);
+        let locPlug = this.plug.at('localization', options.key);
         if('lang' in options) {
             locPlug = locPlug.withParam('lang', options.lang);
         }
         return locPlug.get();
     }
-    static search({ page: page = 1, limit: limit = 10, tags: tags = '', q: q = '', path: path = '' } = {}) {
+    search({ page: page = 1, limit: limit = 10, tags: tags = '', q: q = '', path: path = '' } = {}) {
         let constraint = {};
         if(path !== '') {
             constraint.path = path;
@@ -76,8 +80,6 @@ export default class Site {
             summarypath: encodeURI(path),
             constraint: _buildSearchConstraints(constraint)
         };
-        return Site._getPlug().at('query').withParams(searchParams).get().then((res) => {
-            return SearchModel.parse(res);
-        });
+        return this.plug.at('query').withParams(searchParams).get().then(searchModel.parse);
     }
 }

--- a/test/contextId.test.js
+++ b/test/contextId.test.js
@@ -1,53 +1,60 @@
-import {ContextDefinition, ContextMap} from 'contextId';
+import {Plug} from 'lib/plug';
+import {contextIdsModel} from 'models/contextIds.model';
+import {contextIdModel} from 'models/contextId.model';
+import {contextMapsModel} from 'models/contextMaps.model';
+import {contextMapModel} from 'models/contextMap.model';
+import {ContextIdManager, ContextDefinition, ContextMap} from 'contextId';
 describe('Context ID', () => {
-    beforeEach(() => {
-        jasmine.Ajax.install();
-    });
-    afterEach(() => {
-        jasmine.Ajax.uninstall();
-    });
-    describe('static functionality', () => {
-        let idsUri = '/@api/deki/contexts?';
+    describe('Manager', () => {
+        let cm = null;
+        beforeEach(() => {
+            cm = new ContextIdManager();
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
+            spyOn(contextIdModel, 'parse').and.returnValue({});
+        });
+        afterEach(() => {
+            cm = null;
+        });
         it('can fetch the list of all definitions', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinitions });
-            ContextDefinition.getDefinitions().then((r) => {
+            spyOn(contextIdsModel, 'parse').and.returnValue({});
+            cm.getDefinitions().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can fetch the list of all definitions (single)', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsSingle });
-            ContextDefinition.getDefinitions().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the list of all definitions (empty)', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsEmpty });
-            ContextDefinition.getDefinitions().then((r) => {
+        it('can fetch all context maps', (done) => {
+            spyOn(contextMapsModel, 'parse').and.returnValue({});
+            cm.getMaps().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can add a context ID definition', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsSingle });
-            ContextDefinition.addDefinition('foo').then((r) => {
+            cm.addDefinition('foo').then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can add a context ID definition with a description', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(idsUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinitionsSingle });
-            ContextDefinition.addDefinition('foo', 'Foo description').then((r) => {
+            cm.addDefinition('foo', 'Foo description').then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can fail if an ID is not supplied when trying to add a definition', (done) => {
-            ContextDefinition.addDefinition().catch((e) => {
+            cm.addDefinition().catch((e) => {
                 expect(e.message).toBe('an ID must be supplied to add a definintion');
                 done();
             });
+        });
+        it('can get a content ID Definition by id', () => {
+            let def = cm.getDefinition('foo');
+            expect(def).toBeDefined();
+        });
+        it('can get a content ID Map by language/id', () => {
+            let map = cm.getMap('en-us', 'foo');
+            expect(map).toBeDefined();
         });
     });
     describe('definition constructor', () => {
@@ -61,53 +68,36 @@ describe('Context ID', () => {
     describe('definition instance functions', () => {
         let def = null;
         beforeEach(() => {
+            spyOn(contextIdModel, 'parse').and.returnValue({});
             def = new ContextDefinition('foo');
         });
         afterEach(() => {
             def = null;
         });
-        let defUri = '/@api/deki/contexts/foo?';
         it('can get the definition info', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextIdDefinition });
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
             def.getInfo().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can update the description of a definintion', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinition });
+            spyOn(Plug.prototype, 'put').and.returnValue(Promise.resolve({}));
             def.updateDescription('New Description').then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can implicitly clear the description of a definintion', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextIdDefinition });
+            spyOn(Plug.prototype, 'put').and.returnValue(Promise.resolve({}));
             def.updateDescription().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can delete a definition', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(defUri), null, 'POST').andReturn({ status: 200 });
+            spyOn(Plug.prototype, 'delete').and.returnValue(Promise.resolve({}));
             def.delete().then(() => {
-                done();
-            });
-        });
-    });
-    describe('context map static functionality', () => {
-        let mapsUri = '/@api/deki/contextmaps?';
-        it('can fetch all context maps', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(mapsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMaps });
-            ContextMap.getMaps().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch all context maps (single language)', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(mapsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMapsSingleLanguage });
-            ContextMap.getMaps().then((r) => {
-                expect(r).toBeDefined();
                 done();
             });
         });
@@ -122,30 +112,23 @@ describe('Context ID', () => {
         });
     });
     describe('ContextMap instance functions', () => {
-        let mapUri = '/@api/deki/contextmaps/en-us/foo?';
         let map = null;
         beforeEach(() => {
+            spyOn(contextMapModel, 'parse').and.returnValue({});
             map = new ContextMap('en-us', 'foo');
         });
         afterEach(() => {
             map = null;
         });
         it('can get the info of a map', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMap });
-            map.getInfo().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can get the verbose info of a map', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.contextMapVerbose });
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
             map.getInfo().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can update an existing map', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.contextMapVerbose });
+            spyOn(Plug.prototype, 'put').and.returnValue(Promise.resolve({}));
             map.update(123).then((r) => {
                 expect(r).toBeDefined();
                 done();
@@ -158,7 +141,7 @@ describe('Context ID', () => {
             });
         });
         it('can clear a mapping', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(mapUri), null, 'POST').andReturn({ status: 200 });
+            spyOn(Plug.prototype, 'delete').and.returnValue(Promise.resolve({}));
             map.remove().then((r) => {
                 expect(r).toBeDefined();
                 done();

--- a/test/draft.test.js
+++ b/test/draft.test.js
@@ -16,7 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Draft from 'draft';
+import {Plug} from 'lib/plug';
+import {draftModel} from 'models/draft.model';
+import {Draft} from 'draft';
 describe('Draft', () => {
     describe('constructor tests', () => {
         it('can construct a new Draft object using draft ID', () => {
@@ -43,33 +45,14 @@ describe('Draft', () => {
         let draft = null;
         beforeEach(() => {
             draft = new Draft(123);
-            jasmine.Ajax.install();
         });
         afterEach(() => {
             draft = null;
-            jasmine.Ajax.uninstall();
         });
         it('can get the draft info', (done) => {
-            let fullInfoUri = '/@api/deki/drafts/123?';
-            jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.draft });
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(draftModel, 'parse').and.returnValue({});
             draft.getFullInfo().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can get the draft contents', (done) => {
-            let contentsUri = '/@api/deki/drafts/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.draftContent });
-            draft.getContents().then((r) => {
-                expect(r).toBeDefined();
-                expect(r.draft).toBe(true);
-                done();
-            });
-        });
-        it('can set the draft contents', (done) => {
-            let setUri = '/@api/deki/drafts/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(setUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.draftSetContents });
-            draft.setContents('Sample contents').then((r) => {
                 expect(r).toBeDefined();
                 done();
             });

--- a/test/draft.test.js
+++ b/test/draft.test.js
@@ -40,6 +40,9 @@ describe('Draft', () => {
             expect(draft).toBeDefined();
             expect(draft._id).toBe('home');
         });
+        it('can fail when the constructor is not used correctly', () => {
+            expect(() => Draft()).toThrow();
+        });
     });
     describe('get stuff tests', () => {
         let draft = null;

--- a/test/feedback.test.js
+++ b/test/feedback.test.js
@@ -16,58 +16,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import feedback from 'feedback';
+import {Plug} from 'lib/plug';
+import {pageRatingsModel} from 'models/pageRatings.model';
+import {FeedbackManager} from 'feedback';
 describe('Feedback API', () => {
+    let fm = null;
     beforeEach(() => {
-        jasmine.Ajax.install();
+        fm = new FeedbackManager();
     });
     afterEach(() => {
-        jasmine.Ajax.uninstall();
+        fm = null;
     });
     it('can submit page feedback', (done) => {
-        let feedbackUri = '/@api/deki/workflow/submit-feedback?';
-        jasmine.Ajax.stubRequest(new RegExp(feedbackUri), null, 'POST').andReturn({ status: 200 });
-        feedback.submit({}).then(() => {
-            done();
-        });
-    });
-    it('can handle a page feedback submit error', (done) => {
-        let feedbackUri = '/@api/deki/workflow/submit-feedback?';
-        jasmine.Ajax.stubRequest(new RegExp(feedbackUri), null, 'POST').andReturn({ status: 500 });
-        feedback.submit({}).catch((e) => {
-            expect(e.message).toBe('Status 500 from request');
+        spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
+        fm.submit({}).then(() => {
             done();
         });
     });
     it('can fetch the ratings for a set of pages', (done) => {
-        let ratingsUri = '/@api/deki/pages/ratings?';
-        jasmine.Ajax.stubRequest(new RegExp(ratingsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageRatings });
-        feedback.getRatingsForPages([ 440, 441 ]).then((r) => {
+        spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+        spyOn(pageRatingsModel, 'parse').and.returnValue({});
+        fm.getRatingsForPages([ 440, 441 ]).then((r) => {
             expect(r).toBeDefined();
-            done();
-        });
-    });
-    it('can fetch the ratings for a set of pages (single)', (done) => {
-        let ratingsUri = '/@api/deki/pages/ratings?';
-        jasmine.Ajax.stubRequest(new RegExp(ratingsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageRatingsSingle });
-        feedback.getRatingsForPages([ 440, 441 ]).then((r) => {
-            expect(r).toBeDefined();
-            done();
-        });
-    });
-    it('can fetch the ratings for a set of pages (empty)', (done) => {
-        let ratingsUri = '/@api/deki/pages/ratings?';
-        jasmine.Ajax.stubRequest(new RegExp(ratingsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageRatingsEmpty });
-        feedback.getRatingsForPages([ 440, 441 ]).then((r) => {
-            expect(r).toBeDefined();
-            done();
-        });
-    });
-    it('can handle an error while fetching page ratings', (done) => {
-        let ratingsUri = '/@api/deki/pages/ratings?';
-        jasmine.Ajax.stubRequest(new RegExp(ratingsUri), null, 'GET').andReturn({ status: 400 });
-        feedback.getRatingsForPages([ 440, 441 ]).catch((e) => {
-            expect(e.message).toBe('Status 400 from request');
             done();
         });
     });

--- a/test/feedback.test.js
+++ b/test/feedback.test.js
@@ -20,25 +20,33 @@ import {Plug} from 'lib/plug';
 import {pageRatingsModel} from 'models/pageRatings.model';
 import {FeedbackManager} from 'feedback';
 describe('Feedback API', () => {
-    let fm = null;
-    beforeEach(() => {
-        fm = new FeedbackManager();
-    });
-    afterEach(() => {
-        fm = null;
-    });
-    it('can submit page feedback', (done) => {
-        spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
-        fm.submit({}).then(() => {
-            done();
+    describe('constructor', () => {
+        it('can construct a FeedbackManager', () => {
+            expect(() => new FeedbackManager()).not.toThrow();
+            expect(() => FeedbackManager()).toThrow();
         });
     });
-    it('can fetch the ratings for a set of pages', (done) => {
-        spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
-        spyOn(pageRatingsModel, 'parse').and.returnValue({});
-        fm.getRatingsForPages([ 440, 441 ]).then((r) => {
-            expect(r).toBeDefined();
-            done();
+    describe('instance functions', () => {
+        let fm = null;
+        beforeEach(() => {
+            fm = new FeedbackManager();
+        });
+        afterEach(() => {
+            fm = null;
+        });
+        it('can submit page feedback', (done) => {
+            spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
+            fm.submit({}).then(() => {
+                done();
+            });
+        });
+        it('can fetch the ratings for a set of pages', (done) => {
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(pageRatingsModel, 'parse').and.returnValue({});
+            fm.getRatingsForPages([ 440, 441 ]).then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
         });
     });
 });

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -16,7 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import File from 'file';
+import {Plug} from 'lib/plug';
+import {fileModel} from 'models/file.model';
+import {fileRevisionsModel} from 'models/fileRevisions.model';
+import {File} from 'file';
 describe('File API', () => {
     describe('constructor', () => {
         it('can construct a new File', () => {
@@ -27,64 +30,36 @@ describe('File API', () => {
     describe('operations', () => {
         let file = null;
         beforeEach(() => {
-            jasmine.Ajax.install();
             file = new File(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
         });
         afterEach(() => {
-            jasmine.Ajax.uninstall();
             file = null;
         });
         it('can fetch file info', (done) => {
-            let infoUri = '/@api/deki/files/123/info?';
-            jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.file });
-            file.getInfo().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch a limited file info', (done) => {
-            let infoUri = '/@api/deki/files/123/info?';
-            jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.fileReduced });
+            spyOn(fileModel, 'parse').and.returnValue({});
             file.getInfo().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can fetch file revisions', (done) => {
-            let revisionsUri = '/@api/deki/files/123/revisions?';
-            jasmine.Ajax.stubRequest(new RegExp(revisionsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.fileRevisions });
-            file.getRevisions().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch empty file revisions', (done) => {
-            let revisionsUri = '/@api/deki/files/123/revisions?';
-            jasmine.Ajax.stubRequest(new RegExp(revisionsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.fileRevisionsEmpty });
-            file.getRevisions().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch a single file revision', (done) => {
-            let revisionsUri = '/@api/deki/files/123/revisions?';
-            jasmine.Ajax.stubRequest(new RegExp(revisionsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.fileRevisionsSingle });
+            spyOn(fileRevisionsModel, 'parse').and.returnValue({});
             file.getRevisions().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can set the file description', (done) => {
-            let descUri = '/@api/deki/files/123/description?';
-            jasmine.Ajax.stubRequest(new RegExp(descUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.file });
+            spyOn(Plug.prototype, 'put').and.returnValue(Promise.resolve({}));
+            spyOn(fileModel, 'parse').and.returnValue({});
             file.setDescription('This is the description').then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can delete a file', (done) => {
-            let deleteUri = '/@api/deki/files/123?';
-            jasmine.Ajax.stubRequest(new RegExp(deleteUri), null, 'POST').andReturn({ status: 200 });
+            spyOn(Plug.prototype, 'delete').and.returnValue(Promise.resolve({}));
             file.delete().then(() => {
                 done();
             });

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -25,6 +25,7 @@ describe('File API', () => {
         it('can construct a new File', () => {
             let file = new File(123);
             expect(file).toBeDefined();
+            expect(() => File()).toThrow();
         });
     });
     describe('operations', () => {

--- a/test/groups.test.js
+++ b/test/groups.test.js
@@ -53,9 +53,8 @@ describe('Group API', () => {
             expect(group).toBeDefined();
         });
         it('can fail gracefully when no group ID is provided', () => {
-            expect(() => {
-                new Group();  // eslint-disable-line no-new
-            }).toThrow();
+            expect(() => new Group()).toThrow();
+            expect(() => Group()).toThrow();
         });
     });
     describe('group functionality', () => {

--- a/test/groups.test.js
+++ b/test/groups.test.js
@@ -16,53 +16,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Group from 'group';
+import {Plug} from 'lib/plug';
+import {groupListModel} from 'models/groupList.model';
+import {groupModel} from 'models/group.model';
+import {userListModel} from 'models/userList.model';
+import {GroupManager, Group} from 'group';
 describe('Group API', () => {
+    let gm = null;
     beforeEach(() => {
-        jasmine.Ajax.install();
+        gm = new GroupManager();
     });
     afterEach(() => {
-        jasmine.Ajax.uninstall();
+        gm = null;
     });
-    describe('static functions', () => {
-        let groupsUri = '/@api/deki/groups?';
+    describe('GroupManager', () => {
         it('can get the listing of all of the groups', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(groupsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.groupListing });
-            Group.getGroupList().then((r) => {
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(groupListModel, 'parse').and.returnValue({});
+            gm.getGroupList().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can get an empty listing of the groups', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(groupsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.groupListingEmpty });
-            Group.getGroupList().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can get the listing of a single group', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(groupsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.groupListingSingle });
-            Group.getGroupList().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can handle an HTTP error when fetching the groups', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(groupsUri), null, 'GET').andReturn({ status: 400, responseText: '' });
-            Group.getGroupList().catch((e) => {
-                expect(e.message).toBe('Status 400 from request');
-                done();
-            });
-        });
-        it('can handle invalid JSON when fetching the groups', (done) => {
-            jasmine.Ajax.stubRequest(new RegExp(groupsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            Group.getGroupList().catch((e) => {
-                expect(e.message).toBeDefined();
-                done();
-            });
+        it('can get a Group object by ID', () => {
+            let group = gm.getGroup(132);
+            expect(group).toBeDefined();
         });
     });
-    describe('constructor', () => {
+    describe('Group constructor', () => {
         it('can construct a new Group object from the group ID', () => {
             let group = new Group(2);
             expect(group).toBeDefined();
@@ -81,29 +62,20 @@ describe('Group API', () => {
         let group = null;
         beforeEach(() => {
             group = new Group(2);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
         });
         afterEach(() => {
             group = null;
         });
         it('can fetch a single group', (done) => {
-            let groupUri = '/@api/deki/groups/2?';
-            jasmine.Ajax.stubRequest(new RegExp(groupUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.group });
+            spyOn(groupModel, 'parse').and.returnValue({});
             group.getInfo().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can fetch a group\'s users', (done) => {
-            let usersUri = '/@api/deki/groups/2/users?';
-            jasmine.Ajax.stubRequest(new RegExp(usersUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.groupUsers });
-            group.getUsers().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch a group\'s users (single)', (done) => {
-            let usersUri = '/@api/deki/groups/2/users?';
-            jasmine.Ajax.stubRequest(new RegExp(usersUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.groupUsersSingle });
+            spyOn(userListModel, 'parse').and.returnValue({});
             group.getUsers().then((r) => {
                 expect(r).toBeDefined();
                 done();

--- a/test/mock/drafts.mock.js
+++ b/test/mock/drafts.mock.js
@@ -84,6 +84,25 @@ Mocks.draft = `{
         "username":"admin"
     }
 }`;
+Mocks.draftBasic = `{
+    "@href":"https://editor2.mindtouch.dev/@api/deki/drafts/301",
+    "@state":"unpublished",
+    "@revision":"1",
+    "contents":{
+        "@href":"https://editor2.mindtouch.dev/@api/deki/drafts/301/contents"
+    },
+    "files":{
+        "@count":"0",
+        "@href":"https://editor2.mindtouch.dev/@api/deki/drafts/301/files?redirects=0"
+    },
+    "properties":{
+        "@count":"0",
+        "@href":"https://editor2.mindtouch.dev/@api/deki/drafts/301/properties"
+    },
+    "timeuuid":"45436480-afc9-11e5-80a4-1c1090b42d1e",
+    "title":"Category 3",
+    "uri.ui":"https://editor2.mindtouch.dev/Category_3?mt-draft=true"
+}`;
 Mocks.draftsWithTags = `{
     "pages":{
         "page":[

--- a/test/mock/page.mock.js
+++ b/test/mock/page.mock.js
@@ -146,7 +146,7 @@ Mocks.subpagesSingle = `{
     "@href":"https://www.example.com/@api/deki/pages/123/subpages",
     "page.subpage":{"@id": "456","@href": "https://www.example.com/@api/deki/pages/456?redirects=0", "path": "foo/bar/baz", "title": "Baz"}
 }`;
-Mocks.emptySubpages = `{
+Mocks.subpagesEmpty = `{
     "@totalcount":"0",
     "@count":"0",
     "@href":"https://www.example.com/@api/deki/pages/123/subpages"

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -1,0 +1,168 @@
+import {contextIdModel} from 'models/contextId.model';
+import {contextIdsModel} from 'models/contextIds.model';
+import {contextMapModel} from 'models/contextMap.model';
+import {contextMapsModel} from 'models/contextMaps.model';
+import {draftModel} from 'models/draft.model';
+import {fileModel} from 'models/file.model';
+import {fileRevisionsModel} from 'models/fileRevisions.model';
+import {groupModel} from 'models/group.model';
+import {groupListModel} from 'models/groupList.model';
+import {pageModel} from 'models/page.model';
+import {pageContentsModel} from 'models/pageContents.model';
+import {pageTreeModel} from 'models/pageTree.model';
+import {pageEditModel} from 'models/pageEdit.model';
+import {pageFilesModel} from 'models/pageFiles.model';
+import {pageMoveModel} from 'models/pageMove.model';
+import {pagePropertyModel} from 'models/pageProperty.model';
+import {pagePropertiesModel} from 'models/pageProperties.model';
+import {pageRatingModel} from 'models/pageRating.model';
+import {pageRatingsModel} from 'models/pageRatings.model';
+import {pageTagsModel} from 'models/pageTags.model';
+import {searchModel} from 'models/search.model';
+import {subpagesModel} from 'models/subpages.model';
+import {userModel} from 'models/user.model';
+import {userListModel} from 'models/userList.model';
+describe('Models', () => {
+    describe('Context ID models', () => {
+        it('can parse a context ID', () => {
+            expect(contextIdModel.parse(Mocks.contextIdDefinition)).toBeDefined();
+            expect(contextIdModel.parse(Mocks.contextIdDefinitionsSingle)).toBeDefined();
+        });
+        it('can parse a list of context IDs', () => {
+            expect(contextIdsModel.parse(Mocks.contextIdDefinitions)).toBeDefined();
+            expect(contextIdsModel.parse(Mocks.contextIdDefinitionsSingle)).toBeDefined();
+            expect(contextIdsModel.parse('')).toBeDefined();
+        });
+        it('can parse a context map', () => {
+            expect(contextMapModel.parse(Mocks.contextMap)).toBeDefined();
+            expect(contextMapModel.parse(Mocks.contextMapVerbose)).toBeDefined();
+        });
+        it('can parse a list of context maps', () => {
+            expect(contextMapsModel.parse(Mocks.contextMaps)).toBeDefined();
+            expect(contextMapsModel.parse(Mocks.contextMapsSingleLanguage)).toBeDefined();
+            expect(contextMapsModel.parse(Mocks.contextMapSingleSingle)).toBeDefined();
+            expect(contextMapsModel.parse(Mocks.contextMapsEmpty)).toBeDefined();
+        });
+    });
+    describe('Draft model', () => {
+        it('can parse draft info', () => {
+            expect(draftModel.parse(Mocks.draft)).toBeDefined();
+            expect(draftModel.parse(Mocks.draftBasic)).toBeDefined();
+        });
+    });
+    describe('File model', () => {
+        it('can parse file info', () => {
+            expect(fileModel.parse(Mocks.file)).toBeDefined();
+            expect(fileModel.parse(Mocks.fileReduced)).toBeDefined();
+        });
+        it('can parse a list of file revisions', () => {
+            expect(fileRevisionsModel.parse(Mocks.fileRevisions)).toBeDefined();
+            expect(fileRevisionsModel.parse(Mocks.fileRevisionsSingle)).toBeDefined();
+            expect(fileRevisionsModel.parse(Mocks.fileRevisionsEmpty)).toBeDefined();
+        });
+    });
+    describe('Group model', () => {
+        it('can parse group info', () => {
+            expect(groupModel.parse(Mocks.group)).toBeDefined();
+        });
+        it('can parse a list of groups', () => {
+            expect(groupListModel.parse(Mocks.groupListing)).toBeDefined();
+            expect(groupListModel.parse(Mocks.groupListingSingle)).toBeDefined();
+            expect(groupListModel.parse(Mocks.groupListingEmpty)).toBeDefined();
+        });
+    });
+    describe('Page model', () => {
+        it('can parse page info', () => {
+            expect(pageModel.parse(Mocks.page)).toBeDefined();
+            expect(pageModel.parse(Mocks.pageInfo)).toBeDefined();
+            expect(pageModel.parse(Mocks.virtualPage)).toBeDefined();
+        });
+    });
+    describe('Page contents model', () => {
+        it('can parse page contents info', () => {
+            expect(pageContentsModel.parse(Mocks.pageContent)).toBeDefined();
+            expect(pageContentsModel.parse(Mocks.pageContentSimple)).toBeDefined();
+            expect(pageContentsModel.parse(Mocks.draftContent)).toBeDefined();
+        });
+    });
+    describe('Page tree model', () => {
+        it('can parse page tree info', () => {
+            expect(pageTreeModel.parse(Mocks.pageTree)).toBeDefined();
+        });
+    });
+    describe('Page edit model', () => {
+        it('can parse a page edit info', () => {
+            expect(pageEditModel.parse(Mocks.pageSetContents)).toBeDefined();
+            expect(pageEditModel.parse(Mocks.pageSetContentsConflict)).toBeDefined();
+            expect(pageEditModel.parse(Mocks.draftSetContents)).toBeDefined();
+        });
+    });
+    describe('Page files model', () => {
+        it('can parse page files info', () => {
+            expect(pageFilesModel.parse(Mocks.fileRevisions)).toBeDefined();
+            expect(pageFilesModel.parse(Mocks.fileRevisionsSingle)).toBeDefined();
+            expect(pageFilesModel.parse(Mocks.fileRevisionsEmpty)).toBeDefined();
+        });
+    });
+    describe('Page move model', () => {
+        it('can parse page move info', () => {
+            expect(pageMoveModel.parse(Mocks.pageMove)).toBeDefined();
+            expect(pageMoveModel.parse(Mocks.pageMoveSingle)).toBeDefined();
+            expect(pageMoveModel.parse(Mocks.pageMoveEmpty)).toBeDefined();
+        });
+    });
+    describe('Page properties model', () => {
+        it('can parse page proerty info', () => {
+            expect(pagePropertyModel.parse(Mocks.pageProperty)).toBeDefined();
+            expect(pagePropertyModel.parse(Mocks.pagePropertyPage)).toBeDefined();
+        });
+        it('can parse a list of page properties', () => {
+            expect(pagePropertiesModel.parse(Mocks.pageProperties)).toBeDefined();
+            expect(pagePropertiesModel.parse(Mocks.pagePropertiesSingle)).toBeDefined();
+            expect(pagePropertiesModel.parse(Mocks.pagePropertiesEmpty)).toBeDefined();
+        });
+    });
+    describe('Page ratings model', () => {
+        it('can parse page rating info', () => {
+            expect(pageRatingModel.parse(Mocks.pageRating)).toBeDefined();
+        });
+        it('can parse a list of page ratings', () => {
+            expect(pageRatingsModel.parse(Mocks.pageRatings)).toBeDefined();
+            expect(pageRatingsModel.parse(Mocks.pageRatingsSingle)).toBeDefined();
+            expect(pageRatingsModel.parse(Mocks.pageRatingsEmpty)).toBeDefined();
+        });
+    });
+    describe('Page tags model', () => {
+        it('can parse page tags info', () => {
+            expect(pageTagsModel.parse(Mocks.pageTags)).toBeDefined();
+            expect(pageTagsModel.parse(Mocks.pageTagsSingle)).toBeDefined();
+            expect(pageTagsModel.parse(Mocks.pageTagsEmpty)).toBeDefined();
+        });
+    });
+    describe('Search model', () => {
+        it('can parse search result info', () => {
+            expect(searchModel.parse(Mocks.search)).toBeDefined();
+            expect(searchModel.parse(Mocks.searchSingle)).toBeDefined();
+            expect(searchModel.parse(Mocks.searchEmpty)).toBeDefined();
+        });
+    });
+    describe('Subpages model', () => {
+        it('can parse subpages info', () => {
+            expect(subpagesModel.parse(Mocks.subpages)).toBeDefined();
+            expect(subpagesModel.parse(Mocks.subpagesSingle)).toBeDefined();
+            expect(subpagesModel.parse(Mocks.subpagesEmpty)).toBeDefined();
+        });
+    });
+    describe('Users model', () => {
+        it('can parse user info', () => {
+            expect(userModel.parse(Mocks.user)).toBeDefined();
+        });
+        it('can parse a list of users', () => {
+            expect(userListModel.parse(Mocks.users)).toBeDefined();
+            expect(userListModel.parse(Mocks.usersSingle)).toBeDefined();
+            expect(userListModel.parse(Mocks.userSearch)).toBeDefined();
+            expect(userListModel.parse(Mocks.userSearchSingle)).toBeDefined();
+            expect(userListModel.parse(Mocks.userSearchEmpty)).toBeDefined();
+        });
+    });
+});

--- a/test/page.pro.test.js
+++ b/test/page.pro.test.js
@@ -16,19 +16,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import PageApiPro from 'page.pro';
+import {Plug} from 'lib/plug';
+import {pageMoveModel} from 'models/pageMove.model';
+import {pageEditModel} from 'models/pageEdit.model';
+import {PagePro} from 'page.pro';
 describe('Page Pro', () => {
     describe('constructor', () => {
         it('can construct a Page object with the default ID', () => {
-            let p = new PageApiPro();
+            let p = new PagePro();
             expect(p).toBeDefined();
         });
         it('can construct a Page object with a numeric ID', () => {
-            let p = new PageApiPro(123);
+            let p = new PagePro(123);
             expect(p).toBeDefined();
         });
         it('can construct a Page object with a path as ID', () => {
-            let p = new PageApiPro('Page Title , / ? : @ & = + $ #');
+            let p = new PagePro('Page Title , / ? : @ & = + $ #');
             expect(p).toBeDefined();
             expect(p._id).toEqual('=Page%2520Title%2520%252C%2520%252F%2520%253F%2520%253A%2520%2540%2520%2526%2520%253D%2520%252B%2520%2524%2520%2523');
         });
@@ -36,16 +39,14 @@ describe('Page Pro', () => {
     describe('functions', () => {
         let page = null;
         beforeEach(() => {
-            page = new PageApiPro(123);
-            jasmine.Ajax.install();
+            page = new PagePro(123);
+            spyOn(Plug.prototype, 'put').and.returnValue(Promise.resolve({}));
+            spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
         });
         afterEach(() => {
             page = null;
-            jasmine.Ajax.uninstall();
         });
         it('can set the page overview', (done) => {
-            let overviewUri = '/@api/deki/pages/123/overview?';
-            jasmine.Ajax.stubRequest(new RegExp(overviewUri), null, 'POST').andReturn({ status: 200 });
             page.setOverview({ body: 'FOO' }).then((r) => {
                 expect(r).toBeDefined();
                 done();
@@ -57,74 +58,23 @@ describe('Page Pro', () => {
                 done();
             });
         });
-        it('can fail if an HTTP failure occurs when setting the page overview', (done) => {
-            let overviewUri = '/@api/deki/pages/123/overview?';
-            jasmine.Ajax.stubRequest(new RegExp(overviewUri), null, 'POST').andReturn({ status: 400 });
-            page.setOverview({ body: 'FOO' }).catch((r) => {
-                expect(r.errorCode).toBe(400);
-                done();
-            });
-        });
         it('can move a page', (done) => {
-            let moveUri = '/@api/deki/pages/123/move?';
-            jasmine.Ajax.stubRequest(new RegExp(moveUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageMove });
-            page.move({ to: 'foo/bar' }).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can move a page with a single result', (done) => {
-            let moveUri = '/@api/deki/pages/123/move?';
-            jasmine.Ajax.stubRequest(new RegExp(moveUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageMoveSingle });
-            page.move({ to: 'foo/bar' }).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can move a page with an empty result', (done) => {
-            let moveUri = '/@api/deki/pages/123/move?';
-            jasmine.Ajax.stubRequest(new RegExp(moveUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageMoveEmpty });
+            spyOn(pageMoveModel, 'parse').and.returnValue({});
             page.move({ to: 'foo/bar' }).then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can move a page with no options provided', (done) => {
-            let moveUri = '/@api/deki/pages/123/move?';
-            jasmine.Ajax.stubRequest(new RegExp(moveUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageMove });
+            spyOn(pageMoveModel, 'parse').and.returnValue({});
             page.move().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can handle a page move failure', (done) => {
-            let moveUri = '/@api/deki/pages/123/move?';
-            jasmine.Ajax.stubRequest(new RegExp(moveUri), null, 'POST').andReturn({ status: 400 });
-            page.move({ to: 'foo/bar' }).catch((e) => {
-                expect(e.message).toBe('Status 400 from request');
-                done();
-            });
-        });
         it('can set the page contents', (done) => {
-            let setUri = '/@api/deki/pages/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(setUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageSetContents });
+            spyOn(pageEditModel, 'parse').and.returnValue({});
             page.setContents('Sample contents').then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can set the page contents with options', (done) => {
-            let setUri = '/@api/deki/pages/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(setUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageSetContents });
-            page.setContents('Sample contents', { edittime: 'now' }).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can handle setting the page contents conflict', (done) => {
-            let setUri = '/@api/deki/pages/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(setUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageSetContentsConflict });
-            page.setContents('Sample contents', { edittime: 'now', abort: 'never' }).then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
@@ -132,6 +82,13 @@ describe('Page Pro', () => {
         it('can fail when setting invalid page contents', (done) => {
             page.setContents({}).catch((e) => {
                 expect(e.message).toBe('Contents should be string.');
+                done();
+            });
+        });
+        it('can handle setting the page contents conflict', (done) => {
+            spyOn(pageEditModel, 'parse').and.returnValue({});
+            page.setContents('Sample contents', { edittime: 'now', abort: 'never' }).then((r) => {
+                expect(r).toBeDefined();
                 done();
             });
         });

--- a/test/page.pro.test.js
+++ b/test/page.pro.test.js
@@ -35,6 +35,9 @@ describe('Page Pro', () => {
             expect(p).toBeDefined();
             expect(p._id).toEqual('=Page%2520Title%2520%252C%2520%252F%2520%253F%2520%253A%2520%2540%2520%2526%2520%253D%2520%252B%2520%2524%2520%2523');
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => PagePro()).toThrow();
+        });
     });
     describe('functions', () => {
         let page = null;

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -46,6 +46,9 @@ describe('Page', () => {
             expect(page).toBeDefined();
             expect(page._id).toBe('home');
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => Page()).toThrow();
+        });
     });
     describe('get stuff tests', () => {
         let page = null;

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -16,7 +16,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Page from 'page';
+import {Plug} from 'lib/plug';
+import {pageModel} from 'models/page.model';
+import {pageContentsModel} from 'models/pageContents.model';
+import {subpagesModel} from 'models/subpages.model';
+import {pageTreeModel} from 'models/pageTree.model';
+import {pageTagsModel} from 'models/pageTags.model';
+import {pageRatingModel} from 'models/pageRating.model';
+import {pageFilesModel} from 'models/pageFiles.model';
+import {Page} from 'page';
 describe('Page', () => {
     describe('constructor tests', () => {
         it('can construct a new Page object using page ID', () => {
@@ -43,267 +51,162 @@ describe('Page', () => {
         let page = null;
         beforeEach(() => {
             page = new Page(123);
-            jasmine.Ajax.install();
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(pageModel, 'parse').and.returnValue({});
         });
         afterEach(() => {
             page = null;
             jasmine.Ajax.uninstall();
         });
         it('can get the simple page info', (done) => {
-            let infoUri = '/@api/deki/pages/123/info?';
-            jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageInfo });
             page.getInfo().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can get the simple page info with params', (done) => {
-            let infoUri = '/@api/deki/pages/123/info?';
-            jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageInfo });
             page.getInfo({ exclude: 'revision' }).then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can handle a simple page info request with bad JSON', (done) => {
-            let infoUri = '/@api/deki/pages/123/info?';
-            jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getInfo().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBeDefined();
-                done();
-            });
-        });
-        it('can handle a simple page info request with HTTP failure', (done) => {
-            let infoUri = '/@api/deki/pages/123/info?';
-            jasmine.Ajax.stubRequest(new RegExp(infoUri), null, 'GET').andReturn({ status: 500, responseText: '{ \"message\": \"internal error\" }' });
-            page.getInfo().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.errorCode).toBe(500);
-                expect(r.message).toBe('internal error');
-                done();
-            });
-        });
         it('can get the page info', (done) => {
-            let fullInfoUri = '/@api/deki/pages/123?';
-            jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.page });
             page.getFullInfo().then((r) => {
                 expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can get a virtual page info', (done) => {
-            let fullInfoUri = '/@api/deki/pages/123?';
-            jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 404, responseText: Mocks.virtualPage });
-            page.getFullInfo().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can handle a non-existent page info', (done) => {
-            let fullInfoUri = '/@api/deki/pages/123?';
-            jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 404, responseText: '{ \"message\": \"Could not find requested page\" }' });
-            page.getFullInfo().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBe('Could not find requested page');
-                done();
-            });
-        });
-        it('can get the page info with no parents', (done) => {
-            let fullInfoUri = '/@api/deki/pages/123?';
-            jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageNoParent });
-            page.getFullInfo().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can handle a page info request that returns bad JSON', (done) => {
-            let fullInfoUri = '/@api/deki/pages/123?';
-            jasmine.Ajax.stubRequest(new RegExp(fullInfoUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getFullInfo().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBeDefined();
-                done();
-            });
-        });
-        it('can get the subpages', (done) => {
-            let subpagesUri = '/@api/deki/pages/123/subpages?';
-            jasmine.Ajax.stubRequest(new RegExp(subpagesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.subpages });
-            page.getSubpages().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can get the subpages (single)', (done) => {
-            let subpagesUri = '/@api/deki/pages/123/subpages?';
-            jasmine.Ajax.stubRequest(new RegExp(subpagesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.subpagesSingle });
-            page.getSubpages().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can get the subpages (empty)', (done) => {
-            let subpagesUri = '/@api/deki/pages/123/subpages?';
-            jasmine.Ajax.stubRequest(new RegExp(subpagesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.emptySubpages });
-            page.getSubpages().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can handle a subpages request that returns bad JSON', (done) => {
-            let subpagesUri = '/@api/deki/pages/123/subpages?';
-            jasmine.Ajax.stubRequest(new RegExp(subpagesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getSubpages().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBeDefined();
                 done();
             });
         });
         it('can get the page contents', (done) => {
-            let contentsUri = '/@api/deki/pages/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageContent });
+            spyOn(pageContentsModel, 'parse').and.returnValue({});
             page.getContents().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can get the page contents with a simple body', (done) => {
-            let contentsUri = '/@api/deki/pages/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageContentSimple });
-            page.getContents().then((r) => {
+        it('can get the subpages', (done) => {
+            spyOn(subpagesModel, 'parse').and.returnValue({});
+            page.getSubpages().then((r) => {
                 expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can handle a page contents response that returns bad JSON', (done) => {
-            let contentsUri = '/@api/deki/pages/123/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getContents().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBeDefined();
                 done();
             });
         });
         it('can get the page tree', (done) => {
-            let treeUri = '/@api/deki/pages/123/tree?';
-            jasmine.Ajax.stubRequest(new RegExp(treeUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageTree });
+            spyOn(pageTreeModel, 'parse').and.returnValue({});
             page.getTree().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can handle a page tree response that returns bad JSON', (done) => {
-            let treeUri = '/@api/deki/pages/123/tree?';
-            jasmine.Ajax.stubRequest(new RegExp(treeUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getTree().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBeDefined();
+        it('can get the tags', (done) => {
+            spyOn(pageTagsModel, 'parse').and.returnValue({});
+            page.getTags().then(() => {
                 done();
             });
         });
+        it('can get the user rating', (done) => {
+            spyOn(pageRatingModel, 'parse').and.returnValue({});
+            page.getRating().then(() => {
+                done();
+            });
+        });
+        it('can fetch a template rendered in the context of the Page', (done) => {
+            spyOn(pageContentsModel, 'parse').and.returnValue({});
+            page.getHtmlTemplate('Template:MindTouch/IDF3/Controls/WelcomeMessage').then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fetch a template rendered in the context of the Page with supplied options', (done) => {
+            spyOn(pageContentsModel, 'parse').and.returnValue({});
+            page.getHtmlTemplate('Template:MindTouch/IDF3/Controls/WelcomeMessage', { includes: 'overview' }).then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fetch the page\'s files with default options', (done) => {
+            spyOn(pageFilesModel, 'parse').and.returnValue({});
+            page.getFiles().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fetch the page\'s files with supplied options', (done) => {
+            spyOn(pageFilesModel, 'parse').and.returnValue({});
+            page.getFiles({ limit: 200 }).then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+    });
+    describe('virtual page fetching', () => {
+        it('can get a virtual page info', (done) => {
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.reject({ errorCode: 404, response: { '@virtual': true }}));
+            spyOn(pageModel, 'parse').and.returnValue({});
+            page.getFullInfo().then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can get through virtual page checking when there is another failure', (done) => {
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.reject({ errorCode: 400 }));
+            page.getFullInfo().catch((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+    });
+    describe('tree IDs fetching', () => {
         it('can get the ID path in the tree', (done) => {
-            let treeUri = '/@api/deki/pages/123/tree?';
-            jasmine.Ajax.stubRequest(new RegExp(treeUri), null, 'GET').andReturn({ status: 200, responseText: '123,456,789' });
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve('123,456,789'));
             page.getTreeIds().then((r) => {
                 expect(r).toEqual([ 123, 456, 789 ]);
                 done();
             });
         });
-        it('can handle an invalid tree IDs response', (done) => {
-            let treeUri = '/@api/deki/pages/123/tree?';
-            jasmine.Ajax.stubRequest(new RegExp(treeUri), null, 'GET').andReturn({ status: 200, responseText: 'this is not a list of IDs' });
+        it('can get the ID path in the tree (invalid data)', (done) => {
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve('this is not a list of IDs'));
             page.getTreeIds().catch((r) => {
                 expect(r).toBeDefined();
-                expect(r.message).toBe('Unable to parse the tree IDs.');
                 done();
             });
         });
-        it('can get the tags', (done) => {
-            let tagsUri = '/@api/deki/pages/123/tags?';
-            jasmine.Ajax.stubRequest(new RegExp(tagsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageTags });
-            page.getTags().then(() => {
-                done();
-            });
-        });
-        it('can get the tags (single)', (done) => {
-            let tagsUri = '/@api/deki/pages/123/tags?';
-            jasmine.Ajax.stubRequest(new RegExp(tagsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageTagsSingle });
-            page.getTags().then(() => {
-                done();
-            });
-        });
-        it('can get the tags (empty)', (done) => {
-            let tagsUri = '/@api/deki/pages/123/tags?';
-            jasmine.Ajax.stubRequest(new RegExp(tagsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageTagsEmpty });
-            page.getTags().then(() => {
-                done();
-            });
-        });
-        it('can handle a tags response with bad JSON', (done) => {
-            let tagsUri = '/@api/deki/pages/123/tags?';
-            jasmine.Ajax.stubRequest(new RegExp(tagsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getTags().catch((r) => {
-                expect(r).toBeDefined();
-                expect(r.message).toBeDefined();
-                done();
-            });
-        });
+    });
+    describe('overview fetching', () => {
         it('can get the overview', (done) => {
-            let overviewUri = '/@api/deki/pages/123/overview?';
-            jasmine.Ajax.stubRequest(new RegExp(overviewUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageOverview });
-            page.getOverview().then(() => {
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve(`{ "#text": "this is the overview" }`));
+            page.getOverview().then((r) => {
+                expect(r).toBeDefined();
                 done();
             });
         });
-        it('can fail gracefully when fetching an invalid overview', (done) => {
-            let overviewUri = '/@api/deki/pages/123/overview?';
-            jasmine.Ajax.stubRequest(new RegExp(overviewUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.invalidJson });
-            page.getOverview().catch((e) => {
-                expect(e).toBe('Unable to parse the page overview response');
+        it('can get the overview (invalid response)', (done) => {
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve(`this is invalid JSON`));
+            page.getOverview().catch((r) => {
+                expect(r).toBeDefined();
                 done();
             });
         });
-        it('can get the user rating', (done) => {
-            let ratingUri = '/@api/deki/pages/123/ratings?';
-            jasmine.Ajax.stubRequest(new RegExp(ratingUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageRating });
-            page.getRating().then(() => {
-                done();
-            });
+    });
+    describe('page rating', () => {
+        let page = null;
+        beforeEach(() => {
+            page = new Page(123);
+            spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
+            spyOn(pageRatingModel, 'parse').and.returnValue({});
         });
-        it('can log a page view', (done) => {
-            let viewUri = '/@api/deki/events/page-view/123?';
-            jasmine.Ajax.stubRequest(new RegExp(viewUri), null, 'POST').andReturn({ status: 200 });
-            page.logPageView().then(() => {
-                done();
-            });
-        });
-        it('can rate a page up', (done) => {
-            let rateUri = '/@api/deki/pages/123/ratings?';
-            jasmine.Ajax.stubRequest(new RegExp(rateUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageRating });
+        it('can rate a page', (done) => {
             page.rate(1).then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
-        it('can rate a page down', (done) => {
-            let rateUri = '/@api/deki/pages/123/ratings?';
-            jasmine.Ajax.stubRequest(new RegExp(rateUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageRating });
-            page.rate(0).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can reset a page rating explicitly', (done) => {
-            let rateUri = '/@api/deki/pages/123/ratings?';
-            jasmine.Ajax.stubRequest(new RegExp(rateUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageRating });
-            page.rate('').then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
         it('can reset a page rating implicitly', (done) => {
-            let rateUri = '/@api/deki/pages/123/ratings?';
-            jasmine.Ajax.stubRequest(new RegExp(rateUri), null, 'POST').andReturn({ status: 200, responseText: Mocks.pageRating });
             page.rate().then((r) => {
                 expect(r).toBeDefined();
                 done();
@@ -317,51 +220,12 @@ describe('Page', () => {
             expect(() => page.rate(1, 10)).toThrow();
             expect(() => page.rate(1, { score: 1 })).toThrow();
         });
-        it('can fetch a template rendered in the context of the Page', (done) => {
-            let contentsUri = '/@api/deki/pages/=Template%253AMindTouch%252FIDF3%252FControls%252FWelcomeMessage/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageContent });
-            page.getHtmlTemplate('Template:MindTouch/IDF3/Controls/WelcomeMessage').then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch a template rendered in the context of the Page with supplied options', (done) => {
-            let contentsUri = '/@api/deki/pages/=Template%253AMindTouch%252FIDF3%252FControls%252FWelcomeMessage/contents?';
-            jasmine.Ajax.stubRequest(new RegExp(contentsUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageContent });
-            page.getHtmlTemplate('Template:MindTouch/IDF3/Controls/WelcomeMessage', { includes: 'overview' }).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the page\'s files with default options', (done) => {
-            let filesUri = '/@api/deki/pages/123/files?';
-            jasmine.Ajax.stubRequest(new RegExp(filesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageFiles });
-            page.getFiles().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the page\'s files', (done) => {
-            let filesUri = '/@api/deki/pages/123/files?';
-            jasmine.Ajax.stubRequest(new RegExp(filesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageFiles });
-            page.getFiles({ limit: 200 }).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the page\'s files when there is only one', (done) => {
-            let filesUri = '/@api/deki/pages/123/files?';
-            jasmine.Ajax.stubRequest(new RegExp(filesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageFilesSingle });
-            page.getFiles({ limit: 200 }).then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the page\'s files with an empty response', (done) => {
-            let filesUri = '/@api/deki/pages/123/files?';
-            jasmine.Ajax.stubRequest(new RegExp(filesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageFilesEmpty });
-            page.getFiles({ limit: 200 }).then((r) => {
-                expect(r).toBeDefined();
+    });
+    describe('page view logging', () => {
+        it('can log a page view', (done) => {
+            let page = new Page(123);
+            spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
+            page.logPageView().then(() => {
                 done();
             });
         });

--- a/test/pageHierarchy.test.js
+++ b/test/pageHierarchy.test.js
@@ -33,6 +33,9 @@ describe('Page Hierarchy', () => {
             let ph = new PageHierarchy([ 'topic-category', 'topic-guide' ]);
             expect(ph).toBeDefined();
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => PageHierarchy()).toThrow();
+        });
     });
     describe('operations', () => {
         let ph;

--- a/test/pageProperty.test.js
+++ b/test/pageProperty.test.js
@@ -16,7 +16,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import PageProperty from 'pageProperty';
+import {Plug} from 'lib/plug';
+import {pagePropertiesModel} from 'models/pageProperties.model';
+import {pagePropertyModel} from 'models/pageProperty.model';
+import {PageProperty} from 'pageProperty';
 describe('Page Property', () => {
     describe('constructor tests', () => {
         it('can construct a PageProperty object for the home page implicitly', () => {
@@ -40,39 +43,20 @@ describe('Page Property', () => {
         let prop = null;
         beforeEach(() => {
             prop = new PageProperty(123);
-            jasmine.Ajax.install();
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
         });
         afterEach(() => {
             prop = null;
-            jasmine.Ajax.uninstall();
         });
         it('can fetch the properties from a page', (done) => {
-            let propertiesUri = '/@api/deki/pages/123/properties?';
-            jasmine.Ajax.stubRequest(new RegExp(propertiesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pagePropertiesSingle });
-            prop.getProperties().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the properties from a page (multiple properties)', (done) => {
-            let propertiesUri = '/@api/deki/pages/123/properties?';
-            jasmine.Ajax.stubRequest(new RegExp(propertiesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageProperties });
-            prop.getProperties().then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch the properties from a page (empty)', (done) => {
-            let propertiesUri = '/@api/deki/pages/123/properties?';
-            jasmine.Ajax.stubRequest(new RegExp(propertiesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pagePropertiesEmpty });
+            spyOn(pagePropertiesModel, 'parse').and.returnValue(Mocks.pageProperties);
             prop.getProperties().then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can filter properties by supplying a list of names', (done) => {
-            let propertiesUri = '/@api/deki/pages/123/properties?';
-            jasmine.Ajax.stubRequest(new RegExp(propertiesUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageProperties });
+            spyOn(pagePropertiesModel, 'parse').and.returnValue(Mocks.pageProperties);
             prop.getProperties([ 'property1', 'property2' ]).then((r) => {
                 expect(r).toBeDefined();
                 done();
@@ -85,16 +69,7 @@ describe('Page Property', () => {
             });
         });
         it('can fetch a single property', (done) => {
-            let propertyUri = '/@api/deki/pages/123/properties/mindtouch.import%23info/info?';
-            jasmine.Ajax.stubRequest(new RegExp(propertyUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pageProperty });
-            prop.getProperty('mindtouch.import#info').then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fetch a single property with a page info entry', (done) => {
-            let propertyUri = '/@api/deki/pages/123/properties/mindtouch.import%23info/info?';
-            jasmine.Ajax.stubRequest(new RegExp(propertyUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.pagePropertyPage });
+            spyOn(pagePropertyModel, 'parse').and.returnValue(Mocks.pageProperty);
             prop.getProperty('mindtouch.import#info').then((r) => {
                 expect(r).toBeDefined();
                 done();
@@ -106,31 +81,13 @@ describe('Page Property', () => {
                 done();
             });
         });
-        it('can fetch the contents of a single property', (done) => {
-            let propertyUri = '/@api/deki/pages/123/properties/property1?';
-            jasmine.Ajax.stubRequest(new RegExp(propertyUri), null, 'GET').andReturn({ status: 200, responseText: 'property contents' });
-            prop.getPropertyContents('property1').then((r) => {
-                expect(r).toBeDefined();
-                done();
-            });
-        });
-        it('can fail gracefully if a key is not supplied when fetching the contents of a property', (done) => {
-            prop.getPropertyContents().catch((e) => {
-                expect(e.message).toBe('Attempting to fetch a page property contents without providing a property key');
-                done();
-            });
-        });
         it('can fetch properties from children of the root page', (done) => {
-            let propertyUri = '/@api/deki/pages/123/properties?';
-            jasmine.Ajax.stubRequest(new RegExp(propertyUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.childrenProperties });
             prop.getPropertyForChildren('property1').then((r) => {
                 expect(r).toBeDefined();
                 done();
             });
         });
         it('can fetch properties from children of the root page, and with a supplied depth', (done) => {
-            let propertyUri = '/@api/deki/pages/123/properties?';
-            jasmine.Ajax.stubRequest(new RegExp(propertyUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.childrenProperties });
             prop.getPropertyForChildren('property1', 2).then((r) => {
                 expect(r).toBeDefined();
                 done();
@@ -139,6 +96,18 @@ describe('Page Property', () => {
         it('can fail gracefully if a key is not supplied when fetching children properties', (done) => {
             prop.getPropertyForChildren().catch((e) => {
                 expect(e.message).toBe('Attempting to fetch properties for children without providing a property key');
+                done();
+            });
+        });
+        it('can fetch the contents of a single property', (done) => {
+            prop.getPropertyContents('property1').then((r) => {
+                expect(r).toBeDefined();
+                done();
+            });
+        });
+        it('can fail gracefully if a key is not supplied when fetching the contents of a property', (done) => {
+            prop.getPropertyContents().catch((e) => {
+                expect(e.message).toBe('Attempting to fetch a page property contents without providing a property key');
                 done();
             });
         });

--- a/test/pageProperty.test.js
+++ b/test/pageProperty.test.js
@@ -38,6 +38,9 @@ describe('Page Property', () => {
             let p = new PageProperty('foo/bar');
             expect(p).toBeDefined();
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => PageProperty()).toThrow();
+        });
     });
     describe('fetching tests', () => {
         let prop = null;

--- a/test/plug.test.js
+++ b/test/plug.test.js
@@ -61,6 +61,20 @@ describe('Plug', () => {
             let p = new Plug(settings);
             expect(p.headers['X-Deki-Token']).toBe('abcd1234');
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => Plug()).toThrow();
+        });
+    });
+    describe('constructor with global settings', () => {
+        it('can use a global settings object', () => {
+            window.MartianSettings = new Settings({
+                host: 'http://www.theonehost.org',
+                token: 'theOneToken'
+            });
+            let gPlug = new Plug().at('@api', 'rad', 'endpoint').withParams({ foo: 'bar' });
+            expect(gPlug.getUrl()).toBe('http://www.theonehost.org/@api/rad/endpoint?foo=bar');
+            delete window.MartianSettings;
+        });
     });
     describe('URI manipulation', () => {
         let p = null;

--- a/test/plug.test.js
+++ b/test/plug.test.js
@@ -67,13 +67,13 @@ describe('Plug', () => {
     });
     describe('constructor with global settings', () => {
         it('can use a global settings object', () => {
-            window.MartianSettings = new Settings({
+            Settings.defaults = {
                 host: 'http://www.theonehost.org',
                 token: 'theOneToken'
-            });
+            };
             let gPlug = new Plug().at('@api', 'rad', 'endpoint').withParams({ foo: 'bar' });
             expect(gPlug.getUrl()).toBe('http://www.theonehost.org/@api/rad/endpoint?foo=bar');
-            delete window.MartianSettings;
+            Settings.defaults = {};
         });
     });
     describe('URI manipulation', () => {

--- a/test/plug.test.js
+++ b/test/plug.test.js
@@ -16,56 +16,57 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from 'lib/plug';
-import settings from 'lib/settings';
+import {Plug} from 'lib/plug';
+import {Settings} from 'lib/settings';
 describe('Plug', () => {
     describe('constructor', () => {
-        afterEach(() => {
-            settings.set('host', '');
-            settings.set('token', '');
-        });
-        it('will not construct a Plug with no URL provided', () => {
+        it('will construct a Plug with no URL provided', () => {
             let p = new Plug();
             expect(p).toBeDefined();
             expect(p.at('@api').getUrl()).toBe('/@api');
         });
         it('can create a Plug', () => {
-            let p = new Plug('https://www.example.com');
+            let settings = new Settings({ host: 'https://www.example.com' });
+            let p = new Plug(settings);
             expect(p.getUrl()).toBe('https://www.example.com/');
         });
         it('can create a Plug from a complicated URL', () => {
-            let p = new Plug('https://www.example.com/foo/bar/baz?a=b&c=d&e=f#1=2&3=4');
+            let settings = new Settings({ host: 'https://www.example.com/foo/bar/baz?a=b&c=d&e=f#1=2&3=4' });
+            let p = new Plug(settings);
             expect(p.getUrl()).toBe('https://www.example.com/foo/bar/baz?a=b&c=d&e=f#1=2&3=4');
         });
         it('can construct a Plug with supplied headers', () => {
+            let settings = new Settings({ host: 'https://www.example.com' });
             let headers = { foo: 'bar' };
-            let p = new Plug('https://www.example.com', { headers: headers });
+            let p = new Plug(settings, { headers: headers });
             expect(p.getHeaders()).toEqual(headers);
         });
         it('can construct a Plug with extra construction parameters', () => {
+            let settings = new Settings({ host: 'https://www.example.com/foo?a=b' });
             let params = {
                 segments: [ 'bar', 'baz' ],
                 query: { c: 'd', e: 'f' },
                 excludeQuery: 'a'
             };
-            let p = new Plug('https://www.example.com/foo?a=b', { constructionParams: params });
+            let p = new Plug(settings, { constructionParams: params });
             expect(p.getUrl()).toBe('https://www.example.com/foo/bar/baz?c=d&e=f');
         });
         it('can construct a Plug with the host in the settings', () => {
-            settings.set('host', 'http://www.mindtouch.dev');
-            let p = new Plug().at('foo');
+            let settings = new Settings({ host: 'http://www.mindtouch.dev' });
+            let p = new Plug(settings).at('foo');
             expect(p.getUrl()).toBe('http://www.mindtouch.dev/foo');
         });
         it('can construct a Plug with a token in the settings', () => {
-            settings.set('token', 'abcd1234');
-            let p = new Plug();
+            let settings = new Settings({ token: 'abcd1234' });
+            let p = new Plug(settings);
             expect(p.headers['X-Deki-Token']).toBe('abcd1234');
         });
     });
     describe('URI manipulation', () => {
         let p = null;
         beforeEach(() => {
-            p = new Plug('https://www.example.com/foo?a=b', {
+            let settings = new Settings({ host: 'https://www.example.com/foo?a=b' });
+            p = new Plug(settings, {
                 headers: { 'Cache-Control': 'no-cache' }
             });
         });
@@ -81,6 +82,7 @@ describe('Plug', () => {
             expect(p.getUrl()).toBe('https://www.example.com/foo?a=b');
         });
         it('can add multiple query params', () => {
+            expect(p.withParams().getUrl()).toBe('https://www.example.com/foo?a=b');
             expect(p.withParams({ c: 'd', e: 'f' }).getUrl()).toBe('https://www.example.com/foo?a=b&c=d&e=f');
             expect(p.getUrl()).toBe('https://www.example.com/foo?a=b');
         });
@@ -129,7 +131,8 @@ describe('Plug', () => {
         let uri = 'https://www.example.com/foo';
         let uriMatcher = new RegExp(uri);
         beforeEach(() => {
-            p = new Plug(uri, { raw: true });
+            let settings = new Settings({ host: uri });
+            p = new Plug(settings, { raw: true });
             jasmine.Ajax.install();
         });
         afterEach(() => {
@@ -286,8 +289,8 @@ describe('Plug', () => {
     });
     describe('timeout tests', () => {
         it('can handle an HTTP timeout', (done) => {
-            let uri = 'https://www.example.com/foo';
-            let p = new Plug(uri, { raw: true, constructionParams: { timeout: 1 } });
+            let settings = new Settings({ host: 'https://www.example.com/foo' });
+            let p = new Plug(settings, { raw: true, constructionParams: { timeout: 1 } });
             p.get().catch((e) => {
                 expect(e).toBeDefined();
                 done();

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,6 +1,19 @@
-import settings from 'lib/settings';
+import {Settings} from 'lib/settings';
 describe('Settings', () => {
+    it('can create settings objects', () => {
+        let settings1 = new Settings();
+        let settings2 = new Settings({
+            foo: 'bar',
+            host: 'http://www.example.com'
+        });
+        settings1.set('foo', 'baz');
+        expect(settings1.get('foo')).toBe('baz');
+        expect(settings1.get('host')).not.toBeDefined();
+        expect(settings2.get('foo')).toBe('bar');
+        expect(settings2.get('host')).toBe('http://www.example.com');
+    });
     it('can set settings values', () => {
+        let settings = new Settings();
         settings.set('foo', 'bar');
         settings.set('abc', 123);
         settings.set('object', { dog: 'cat' });
@@ -11,5 +24,21 @@ describe('Settings', () => {
         expect(newSettings.foo).toBe('bar');
         expect(newSettings.abc).toBe(123);
         expect(newSettings.object).toEqual({ dog: 'cat' });
+    });
+    it('can clone a settings object', () => {
+        let settings = new Settings({ foo: 'bar', abc: 123 });
+        let settings2 = settings.clone({ foo: 'baz' });
+        expect(settings.get('foo')).toBe('bar');
+        expect(settings2.get('foo')).toBe('baz');
+        expect(settings.get('abc')).toBe(123);
+        expect(settings2.get('abc')).toBe(123);
+    });
+    it('can clone a settings object with no overrides', () => {
+        let settings = new Settings({ foo: 'bar', abc: 123 });
+        let settings2 = settings.clone();
+        expect(settings.get('foo')).toBe('bar');
+        expect(settings2.get('foo')).toBe('bar');
+        expect(settings.get('abc')).toBe(123);
+        expect(settings2.get('abc')).toBe(123);
     });
 });

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,5 +1,14 @@
 import {Settings} from 'lib/settings';
 describe('Settings', () => {
+    it('can get and set a single config item', () => {
+        Settings.defaults = {
+            abc: 123,
+            foo: 'bar'
+        };
+        let defSettings = new Settings();
+        expect(defSettings.get('abc')).toBe(123);
+        expect(defSettings.get('foo')).toBe('bar');
+    });
     it('can create settings objects', () => {
         let settings1 = new Settings();
         let settings2 = new Settings({
@@ -21,7 +30,7 @@ describe('Settings', () => {
         expect(settings.get('foo')).toBe('bar');
         expect(settings.get('abc')).toBe(123);
         expect(settings.get('object')).toEqual({ dog: 'cat' });
-        let newSettings = settings.getSettings();
+        let newSettings = settings.getProperties();
         expect(newSettings.foo).toBe('bar');
         expect(newSettings.abc).toBe(123);
         expect(newSettings.object).toEqual({ dog: 'cat' });

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -11,6 +11,7 @@ describe('Settings', () => {
         expect(settings1.get('host')).not.toBeDefined();
         expect(settings2.get('foo')).toBe('bar');
         expect(settings2.get('host')).toBe('http://www.example.com');
+        expect(() => Settings()).toThrow();
     });
     it('can set settings values', () => {
         let settings = new Settings();

--- a/test/site.test.js
+++ b/test/site.test.js
@@ -16,89 +16,80 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Site from 'site';
+import {Plug} from 'lib/plug';
+import {searchModel} from 'models/search.model';
+import {Settings} from 'lib/settings';
+import {SiteManager} from 'site';
 describe('Site API', () => {
+    let settings = new Settings({
+        host: 'https://www.example.com',
+        token: 'abcd1234'
+    });
     describe('construction', () => {
         it('fails when calling Site as a function', () => {
-            expect(() => Site()).toThrow();
+            expect(() => SiteManager()).toThrow();
         });
         it('can attempt to construct a Site object', () => {
-            let site = new Site();
-            expect(site).toBeDefined();
+            let site1 = new SiteManager();
+            expect(site1).toBeDefined();
+            let site2 = new SiteManager(settings);
+            expect(site2).toBeDefined();
         });
     });
-    describe('static operations', () => {
+    describe('resource string operations', () => {
+        let sm = null;
         beforeEach(() => {
-            jasmine.Ajax.install();
-        });
-        afterEach(() => {
-            jasmine.Ajax.uninstall();
+            sm = new SiteManager(settings);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve('translated string'));
         });
         it('can fetch a translated string', (done) => {
-            let locUri = '/@api/deki/site/localization/Test.Resource.key?';
-            jasmine.Ajax.stubRequest(new RegExp(locUri), null, 'GET').andReturn({ status: 200, responseText: 'Translated string' });
-            Site.getResourceString({ key: 'Test.Resource.key' }).then((r) => {
-                expect(r).toBe('Translated string');
+            sm.getResourceString({ key: 'Test.Resource.key' }).then((r) => {
+                expect(r).toBeDefined();
                 done();
             });
         });
         it('can fetch a translated string with language supplied', (done) => {
-            let locUri = '/@api/deki/site/localization/Test.Resource.key?';
-            jasmine.Ajax.stubRequest(new RegExp(locUri), null, 'GET').andReturn({ status: 200, responseText: 'Translated string' });
-            Site.getResourceString({ key: 'Test.Resource.key', lang: 'en-us' }).then((r) => {
-                expect(r).toBe('Translated string');
+            sm.getResourceString({ key: 'Test.Resource.key', lang: 'en-us' }).then((r) => {
+                expect(r).toBeDefined();
                 done();
             });
         });
         it('can fail if no resource key is supplied', () => {
-            Site.getResourceString().catch((e) => {
+            sm.getResourceString().catch((e) => {
                 expect(e).toBeDefined();
             });
         });
+    });
+    describe('search operations', () => {
+        let sm = new SiteManager(settings);
+        beforeEach(() => {
+            sm = new SiteManager(settings);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve());
+        });
         it('can perform a default search', (done) => {
-            let searchUri = '/@api/deki/site/query?';
-            jasmine.Ajax.stubRequest(new RegExp(searchUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.search });
-            Site.search().then((e) => {
+            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            sm.search().then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
         });
         it('can perform a search with some parameters', (done) => {
-            let searchUri = '/@api/deki/site/query?';
-            jasmine.Ajax.stubRequest(new RegExp(searchUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.search });
-            Site.search({ page: 123, tags: [ 'abc', '123' ] }).then((e) => {
+            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            sm.search({ page: 123, tags: [ 'abc', '123' ] }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
         });
         it('can perform a search with some other parameters', (done) => {
-            let searchUri = '/@api/deki/site/query?';
-            jasmine.Ajax.stubRequest(new RegExp(searchUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.search });
-            Site.search({ path: 'foo/bar', q: 'search thing' }).then((e) => {
+            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            sm.search({ path: 'foo/bar', q: 'search thing' }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
         });
         it('can perform a search with all parameters', (done) => {
-            let searchUri = '/@api/deki/site/query?';
-            jasmine.Ajax.stubRequest(new RegExp(searchUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.search });
-            Site.search({ path: '/foo/bar', tags: 'abc', page: 123, limit: 10, q: 'search term' }).then((e) => {
-                expect(e).toBeDefined();
-                done();
-            });
-        });
-        it('can perform a search that returns a single result', (done) => {
-            let searchUri = '/@api/deki/site/query?';
-            jasmine.Ajax.stubRequest(new RegExp(searchUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.searchSingle });
-            Site.search({ path: '/foo/bar', tags: 'abc', page: 123, limit: 10, q: 'search term' }).then((e) => {
-                expect(e).toBeDefined();
-                done();
-            });
-        });
-        it('can perform a search that returns no results', (done) => {
-            let searchUri = '/@api/deki/site/query?';
-            jasmine.Ajax.stubRequest(new RegExp(searchUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.searchEmpty });
-            Site.search({ path: '/foo/bar', tags: 'abc', page: 123, limit: 10, q: 'search term' }).then((e) => {
+            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            sm.search({ path: '/foo/bar', tags: 'abc', page: 123, limit: 10, q: 'search term' }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });

--- a/test/site.test.js
+++ b/test/site.test.js
@@ -64,31 +64,31 @@ describe('Site API', () => {
         let sm = new SiteManager(settings);
         beforeEach(() => {
             sm = new SiteManager(settings);
-            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve());
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
         });
         it('can perform a default search', (done) => {
-            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            spyOn(searchModel, 'parse').and.returnValue({});
             sm.search().then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
         });
         it('can perform a search with some parameters', (done) => {
-            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            spyOn(searchModel, 'parse').and.returnValue({});
             sm.search({ page: 123, tags: [ 'abc', '123' ] }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
         });
         it('can perform a search with some other parameters', (done) => {
-            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            spyOn(searchModel, 'parse').and.returnValue({});
             sm.search({ path: 'foo/bar', q: 'search thing' }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
         });
         it('can perform a search with all parameters', (done) => {
-            spyOn(searchModel, 'parse').and.returnValue(Mocks.search);
+            spyOn(searchModel, 'parse').and.returnValue({});
             sm.search({ path: '/foo/bar', tags: 'abc', page: 123, limit: 10, q: 'search term' }).then((e) => {
                 expect(e).toBeDefined();
                 done();

--- a/test/site.test.js
+++ b/test/site.test.js
@@ -19,7 +19,7 @@
 import {Plug} from 'lib/plug';
 import {searchModel} from 'models/search.model';
 import {Settings} from 'lib/settings';
-import {SiteManager} from 'site';
+import {Site} from 'site';
 describe('Site API', () => {
     let settings = new Settings({
         host: 'https://www.example.com',
@@ -27,19 +27,19 @@ describe('Site API', () => {
     });
     describe('construction', () => {
         it('fails when calling Site as a function', () => {
-            expect(() => SiteManager()).toThrow();
+            expect(() => Site()).toThrow();
         });
         it('can attempt to construct a Site object', () => {
-            let site1 = new SiteManager();
+            let site1 = new Site();
             expect(site1).toBeDefined();
-            let site2 = new SiteManager(settings);
+            let site2 = new Site(settings);
             expect(site2).toBeDefined();
         });
     });
     describe('resource string operations', () => {
         let sm = null;
         beforeEach(() => {
-            sm = new SiteManager(settings);
+            sm = new Site(settings);
             spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve('translated string'));
         });
         it('can fetch a translated string', (done) => {
@@ -61,10 +61,13 @@ describe('Site API', () => {
         });
     });
     describe('search operations', () => {
-        let sm = new SiteManager(settings);
+        let sm = null;
         beforeEach(() => {
-            sm = new SiteManager(settings);
+            sm = new Site(settings);
             spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+        });
+        afterEach(() => {
+            sm = null;
         });
         it('can perform a default search', (done) => {
             spyOn(searchModel, 'parse').and.returnValue({});

--- a/test/stringUtility.test.js
+++ b/test/stringUtility.test.js
@@ -1,4 +1,4 @@
-import stringUtility from 'lib/stringUtility';
+import {stringUtility} from 'lib/stringUtility';
 describe('string utility tests', () => {
     it('can check if a string is blank', () => {
         expect(stringUtility.isBlank()).toBe(true);
@@ -38,5 +38,9 @@ describe('string utility tests', () => {
         expect(stringUtility.words('foo   bar')).toEqual([ 'foo', 'bar' ]);
         expect(stringUtility.words('foo/bar', '/')).toEqual([ 'foo', 'bar' ]);
         expect(stringUtility.words('foo/bar', '9')).toEqual([ 'foo/bar' ]);
+    });
+    it('can check if a string starts with a pattern', () => {
+        expect(stringUtility.startsWith('foobar', 'foo')).toBe(true);
+        expect(stringUtility.startsWith('foobar', 'oo')).toBe(false);
     });
 });

--- a/test/uri.test.js
+++ b/test/uri.test.js
@@ -27,6 +27,9 @@ describe('URI', () => {
             let uri = new Uri();
             expect(uri).toBeDefined();
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => Uri()).toThrow();
+        });
     });
     describe('functionality', () => {
         var uri = null;

--- a/test/uri.test.js
+++ b/test/uri.test.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Uri from 'lib/uri';
+import {Uri} from 'lib/uri';
 describe('URI', () => {
     describe('constructor tests', () => {
         it('can construct a plain URI', () => {

--- a/test/uriParser.test.js
+++ b/test/uriParser.test.js
@@ -43,6 +43,9 @@ describe('URI Parser', () => {
                 expect(x).not.toBeDefined();
             }).toThrow();
         });
+        it('can fail if the constructor is not called correctly', () => {
+            expect(() => UriParser()).toThrow();
+        });
     });
     describe('URI operations', () => {
         let uri = null;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -36,8 +36,8 @@ describe('User API', () => {
         let userManager = null;
         beforeEach(() => {
             userManager = new UserManager(settings);
-            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve());
-            spyOn(userModel, 'parse').and.returnValue(Mocks.user);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(userModel, 'parse').and.returnValue({});
         });
         it('can fetch the current user', (done) => {
             userManager.getCurrentUser().then((u) => {
@@ -46,28 +46,28 @@ describe('User API', () => {
             });
         });
         it('can fetch the list of all users', (done) => {
-            spyOn(userListModel, 'parse').and.returnValue(Mocks.users);
+            spyOn(userListModel, 'parse').and.returnValue({});
             userManager.getUsers().then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch a list of filtered users', (done) => {
-            spyOn(userListModel, 'parse').and.returnValue(Mocks.userSearch);
+            spyOn(userListModel, 'parse').and.returnValue({});
             userManager.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch a list of filtered users (single)', (done) => {
-            spyOn(userListModel, 'parse').and.returnValue(Mocks.userSearchSingle);
+            spyOn(userListModel, 'parse').and.returnValue({});
             userManager.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch a list of filtered users (empty)', (done) => {
-            spyOn(userListModel, 'parse').and.returnValue(Mocks.userSearchEmpty);
+            spyOn(userListModel, 'parse').and.returnValue({});
             userManager.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
                 expect(u).toBeDefined();
                 done();
@@ -82,8 +82,8 @@ describe('User API', () => {
     });
     describe('instance operations', () => {
         beforeEach(() => {
-            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve());
-            spyOn(userModel, 'parse').and.returnValue(Mocks.user);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve({}));
+            spyOn(userModel, 'parse').and.returnValue({});
         });
         it('can construct a User without the manager', () => {
             let user1 = new User();

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -16,80 +16,85 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import User from 'user';
+import {Plug} from 'lib/plug';
+import {Settings} from 'lib/settings';
+import {userModel} from 'models/user.model';
+import {userListModel} from 'models/userList.model';
+import {UserManager, User} from 'user';
 describe('User API', () => {
+    let settings = new Settings({ host: 'http://www.example.com', token: 'abcd1234' });
     describe('constructor', () => {
         it('can perform construction operations', () => {
-            expect(() => User()).toThrow();
-            let u = new User();
+            expect(() => UserManager()).toThrow();
+            let u = new UserManager();
             expect(u).toBeDefined();
-            let u2 = new User(123);
+            let u2 = new UserManager(settings);
             expect(u2).toBeDefined();
-            let u3 = new User('foobar');
-            expect(u3).toBeDefined();
         });
     });
     describe('static operations', () => {
+        let userManager = null;
         beforeEach(() => {
-            jasmine.Ajax.install();
-        });
-        afterEach(() => {
-            jasmine.Ajax.uninstall();
+            userManager = new UserManager(settings);
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve());
+            spyOn(userModel, 'parse').and.returnValue(Mocks.user);
         });
         it('can fetch the current user', (done) => {
-            let currentUri = '/@api/deki/users/current?';
-            jasmine.Ajax.stubRequest(new RegExp(currentUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.user });
-            User.getCurrentUser().then((u) => {
+            userManager.getCurrentUser().then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch the list of all users', (done) => {
-            let usersUri = '/@api/deki/users?';
-            jasmine.Ajax.stubRequest(new RegExp(usersUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.users });
-            User.getUsers().then((u) => {
+            spyOn(userListModel, 'parse').and.returnValue(Mocks.users);
+            userManager.getUsers().then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch a list of filtered users', (done) => {
-            let usersUri = '/@api/deki/users/search?';
-            jasmine.Ajax.stubRequest(new RegExp(usersUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.userSearch });
-            User.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
+            spyOn(userListModel, 'parse').and.returnValue(Mocks.userSearch);
+            userManager.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch a list of filtered users (single)', (done) => {
-            let usersUri = '/@api/deki/users/search?';
-            jasmine.Ajax.stubRequest(new RegExp(usersUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.userSearchSingle });
-            User.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
+            spyOn(userListModel, 'parse').and.returnValue(Mocks.userSearchSingle);
+            userManager.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
         it('can fetch a list of filtered users (empty)', (done) => {
-            let usersUri = '/@api/deki/users/search?';
-            jasmine.Ajax.stubRequest(new RegExp(usersUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.userSearchEmpty });
-            User.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
+            spyOn(userListModel, 'parse').and.returnValue(Mocks.userSearchEmpty);
+            userManager.searchUsers({ username: 'foo', limit: 20 }).then((u) => {
                 expect(u).toBeDefined();
                 done();
             });
         });
+        it('can fetch a user', () => {
+            let u1 = userManager.getUser();
+            expect(u1).toBeDefined();
+            let u2 = userManager.getUser(1);
+            expect(u2).toBeDefined();
+        });
     });
     describe('instance operations', () => {
-        let user = null;
         beforeEach(() => {
-            user = new User(2);
-            jasmine.Ajax.install();
+            spyOn(Plug.prototype, 'get').and.returnValue(Promise.resolve());
+            spyOn(userModel, 'parse').and.returnValue(Mocks.user);
         });
-        afterEach(() => {
-            user = null;
-            jasmine.Ajax.uninstall();
+        it('can construct a User without the manager', () => {
+            let user1 = new User();
+            expect(user1).toBeDefined();
+            let user2 = new User(settings);
+            expect(user2).toBeDefined();
+            let user3 = new User(123, settings);
+            expect(user3).toBeDefined();
         });
-        it('can fetch a specific user', (done) => {
-            let userUri = '/@api/deki/users/2?';
-            jasmine.Ajax.stubRequest(new RegExp(userUri), null, 'GET').andReturn({ status: 200, responseText: Mocks.user });
+        it('can get the info for a user', (done) => {
+            let user = new User(123, settings);
             user.getInfo().then((u) => {
                 expect(u).toBeDefined();
                 done();

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -1,4 +1,4 @@
-import utility from 'lib/utility';
+import {utility} from 'lib/utility';
 describe('Martian utility', () => {
     it('can escape a string for search queries', () => {
         let unescaped = '1111\\+-&|!(){}[]^"~*?:2222';

--- a/user.js
+++ b/user.js
@@ -16,31 +16,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Plug from './lib/plug';
-import utility from './lib/utility';
-import userModel from './models/user.model';
-import userListModel from './models/userList.model';
-export default class User {
-    static _getPlug() {
-        if(!this.userPlug) {
-            this.userPlug = new Plug().at('@api', 'deki', 'users');
-        }
-        return this.userPlug;
-    }
-    static getCurrentUser() {
-        return User._getPlug().at('current').get().then(userModel.parse);
-    }
-    static getUsers() {
-        return User._getPlug().get().then(userListModel.parse);
-    }
-    static searchUsers(constraints) {
-        return User._getPlug().at('search').withParams(constraints).get().then(userListModel.parse);
-    }
-    constructor(id = 'current') {
+import {Plug} from './lib/plug';
+import {utility} from './lib/utility';
+import {userModel} from './models/user.model';
+import {userListModel} from './models/userList.model';
+export class User {
+    constructor(id = 'current', settings) {
         this._id = utility.getResourceId(id, 'current');
-        this._plug = User._getPlug().at(this._id);
+        this._plug = new Plug(settings).at('@api', 'deki', 'users', this._id);
     }
     getInfo() {
         return this._plug.get().then(userModel.parse);
+    }
+}
+export class UserManager {
+    constructor(settings) {
+        this.settings = settings;
+        this.plug = new Plug(settings).at('@api', 'deki', 'users');
+    }
+    getCurrentUser() {
+        return this.plug.at('current').get().then(userModel.parse);
+    }
+    getUsers() {
+        return this.plug.get().then(userListModel.parse);
+    }
+    searchUsers(constraints) {
+        return this.plug.at('search').withParams(constraints).get().then(userListModel.parse);
+    }
+    getUser(id = 'current') {
+        return new User(id, this.settings);
     }
 }


### PR DESCRIPTION
Reviewed by @derekrobbins 

This change allows a distinct Settings instance to be passed in to every martian constructor, allowing for multiple hosts to be targeted following a single load of the martian module.

Other changes related to this work:
*Move to named exports for every martian module for more consistent import patterns.
*Remove Ajax mocking in favor of Jasmine spies (except for in the Plug tests)
*Add specific tests for the models, rather than relying on the controller tests to cover them implicitly
*Moved static functionality from a few modules into a dedicated Manager class to handle the functionality