### PR TITLE
Add User permissions parsing / fix `recommendations` param in search

### DIFF
--- a/models/permissions.model.js
+++ b/models/permissions.model.js
@@ -1,0 +1,14 @@
+import {modelHelper} from './modelHelper';
+export let permissionsModel = {
+    parse(data) {
+        let obj = modelHelper.fromJson(data);
+        let parsed = {
+            operations: modelHelper.getString(obj.operations).split(','),
+            role: {
+                id: modelHelper.getInt(obj.role['@id']),
+                name: modelHelper.getString(obj.role)
+            }
+        };
+        return parsed;
+    }
+};

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -18,6 +18,7 @@
  */
 import {modelHelper} from './modelHelper';
 import {pageModel} from './page.model';
+import {permissionsModel} from './permissions.model';
 let userModel = {
     parse: function(data) {
         let obj = modelHelper.fromJson(data);
@@ -26,7 +27,6 @@ let userModel = {
             wikiId: obj['@wikiid'],
             href: obj['@href'],
             dateCreated: modelHelper.getDate(obj['date.created']),
-            dateLastLogin: modelHelper.getDate(obj['date.lastlogin']),
             email: obj.email,
             fullname: obj.fullname,
             username: obj.username,
@@ -34,8 +34,14 @@ let userModel = {
             status: obj.status,
             licenseSeat: modelHelper.getBool(obj['license.seat'])
         };
+        if('date.lastlogin' in obj) {
+            parsed.dateLastLogin = modelHelper.getDate(obj['date.lastlogin']);
+        }
         if('page.home' in obj) {
             parsed.pageHome = pageModel.parse(obj['page.home']);
+        }
+        if('permissions.user' in obj) {
+            parsed.userPermissions = permissionsModel.parse(obj['permissions.user']);
         }
         return parsed;
     }


### PR DESCRIPTION
Reviewed by @killsunday 

Add user permissions parsing through a new permissions model.  Used in the user model.
Make parsing of the last login date conditional (might not be returned by the API)
