### PR TITLE
Properly parse the seated/owner info from user models

### DIFF
--- a/models/user.model.js
+++ b/models/user.model.js
@@ -35,6 +35,7 @@ let userModel = {
         };
         if(typeof obj['license.seat'] === 'string') {
             parsed.seated = modelHelper.getBool(obj['license.seat']);
+            parsed.siteOwner = false;
         } else {
             parsed.seated = modelHelper.getBool(modelHelper.getString(obj['license.seat']));
             parsed.siteOwner = modelHelper.getBool(obj['license.seat']['@owner']);

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -31,9 +31,14 @@ let userModel = {
             fullname: obj.fullname,
             username: obj.username,
             nick: obj.nick,
-            status: obj.status,
-            licenseSeat: modelHelper.getBool(obj['license.seat'])
+            status: obj.status
         };
+        if(typeof obj['license.seat'] === 'string') {
+            parsed.seated = modelHelper.getBool(obj['license.seat']);
+        } else {
+            parsed.seated = modelHelper.getBool(modelHelper.getString(obj['license.seat']));
+            parsed.siteOwner = modelHelper.getBool(obj['license.seat']['@owner']);
+        }
         if('date.lastlogin' in obj) {
             parsed.dateLastLogin = modelHelper.getDate(obj['date.lastlogin']);
         }


### PR DESCRIPTION
Reviewed by @derekrobbins 

When an user is the site owner, the `license.seat` property is an object rather than a boolean string.
In this case, we need to pull out the "seated" Boolean as well as the "Site Owner" Boolean.

This change ensures both params are set in the parsed response object.