### PR TITLE
Fix code coverage with a refactor of the origin setting handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,8 @@ script: gulp
 
 after_success:
   - cat coverage/*/lcov.info | codecov
+
+cache:
+  directories:
+  - node_modules
+  - jspm_packages

--- a/lib/plug.js
+++ b/lib/plug.js
@@ -33,10 +33,6 @@ function _handleHttpError(xhr) {
 function _getText(xhr) {
     return Promise.resolve(xhr.responseText || '');
 }
-function _getBaseOriginUrlString(uri) {
-    let parts = uri.parsedUrl.parts;
-    return (parts.protocol + '//' + parts.hostname).toLowerCase();
-}
 function _doRequest(params) {
     return new Promise((resolve, reject) => {
         let xhr = new XMLHttpRequest();
@@ -56,9 +52,11 @@ function _doRequest(params) {
 
         // X-Deki-Requested-With (required for web widgets same-origin xhr)
         let originUrlString = this.settings.get('origin');
-        if(originUrlString && originUrlString !== '' &&
-            (_getBaseOriginUrlString(url) === _getBaseOriginUrlString(new Uri(originUrlString)))) {
-            xhr.setRequestHeader('X-Deki-Requested-With', 'XMLHttpRequest');
+        if(originUrlString && originUrlString !== '') {
+            let originUri = new Uri(originUrlString);
+            if(url.origin === originUri.origin) {
+                xhr.setRequestHeader('X-Deki-Requested-With', 'XMLHttpRequest');
+            }
         }
         Object.keys(this.headers).forEach((key) => {
             xhr.setRequestHeader(key, this.headers[key]);

--- a/lib/uri.js
+++ b/lib/uri.js
@@ -25,6 +25,9 @@ export class Uri {
     get protocol() {
         return this.parsedUrl.protocol;
     }
+    get origin() {
+        return this.parsedUrl.origin;
+    }
     removeQueryParam(key) {
         this.parsedUrl.searchParams.delete(key);
         return this;

--- a/lib/uriParser.js
+++ b/lib/uriParser.js
@@ -111,7 +111,7 @@ export class UriParser {
 
     // Properties that come directly from the regex
     get protocol() {
-        return this.parts.protocol;
+        return this.parts.protocol.toLowerCase();
     }
     set protocol(val) {
         this.parts.protocol = val;
@@ -169,7 +169,7 @@ export class UriParser {
         this.search = this.parts.search;
     }
     get host() {
-        let host = this.hostname;
+        let host = this.hostname.toLowerCase();
         if(this.port) {
             host = `${host}:${this.port}`;
         }

--- a/test/plug.test.js
+++ b/test/plug.test.js
@@ -303,6 +303,27 @@ describe('Plug', () => {
             });
         });
     });
+    describe('same origin tests', () => {
+        let uri = 'https://www.example.com/foo';
+        let settings = new Settings({ host: uri, origin: 'https://www.example.com' });
+        let uriMatcher = new RegExp(uri);
+        beforeEach(() => {
+            jasmine.Ajax.install();
+        });
+        afterEach(() => {
+            jasmine.Ajax.uninstall();
+        });
+        it('can do a request with the origin the same as the request URI', (done) => {
+            let plug = new Plug(settings);
+            jasmine.Ajax.stubRequest(uriMatcher, null, 'GET').andReturn({ status: 200, responseText: 'Ajax Response' });
+            plug.get().then(() => {
+                let headers = jasmine.Ajax.requests.mostRecent().requestHeaders;
+                expect('X-Deki-Requested-With' in headers).toBe(true);
+                expect(headers['X-Deki-Requested-With']).toBe('XMLHttpRequest');
+                done();
+            });
+        });
+    });
     describe('timeout tests', () => {
         let p = null;
         let uri = 'https://www.example.com/foo';

--- a/test/plug.test.js
+++ b/test/plug.test.js
@@ -305,7 +305,6 @@ describe('Plug', () => {
     });
     describe('same origin tests', () => {
         let uri = 'https://www.example.com/foo';
-        let settings = new Settings({ host: uri, origin: 'https://www.example.com' });
         let uriMatcher = new RegExp(uri);
         beforeEach(() => {
             jasmine.Ajax.install();
@@ -314,12 +313,34 @@ describe('Plug', () => {
             jasmine.Ajax.uninstall();
         });
         it('can do a request with the origin the same as the request URI', (done) => {
+            let settings = new Settings({ host: uri, origin: 'https://www.example.com' });
             let plug = new Plug(settings);
             jasmine.Ajax.stubRequest(uriMatcher, null, 'GET').andReturn({ status: 200, responseText: 'Ajax Response' });
             plug.get().then(() => {
                 let headers = jasmine.Ajax.requests.mostRecent().requestHeaders;
                 expect('X-Deki-Requested-With' in headers).toBe(true);
                 expect(headers['X-Deki-Requested-With']).toBe('XMLHttpRequest');
+                done();
+            });
+        });
+        it('can do a request with the origin the same as the request URI (case insensitive)', (done) => {
+            let settings = new Settings({ host: uri, origin: 'https://WWW.EXAMPLE.COM' });
+            let plug = new Plug(settings);
+            jasmine.Ajax.stubRequest(uriMatcher, null, 'GET').andReturn({ status: 200, responseText: 'Ajax Response' });
+            plug.get().then(() => {
+                let headers = jasmine.Ajax.requests.mostRecent().requestHeaders;
+                expect('X-Deki-Requested-With' in headers).toBe(true);
+                expect(headers['X-Deki-Requested-With']).toBe('XMLHttpRequest');
+                done();
+            });
+        });
+        it('can do a request with the origin different from the request URI', (done) => {
+            let settings = new Settings({ host: uri, origin: 'https://www.example.org' });
+            let plug = new Plug(settings);
+            jasmine.Ajax.stubRequest(uriMatcher, null, 'GET').andReturn({ status: 200, responseText: 'Ajax Response' });
+            plug.get().then(() => {
+                let headers = jasmine.Ajax.requests.mostRecent().requestHeaders;
+                expect('X-Deki-Requested-With' in headers).toBe(false);
                 done();
             });
         });


### PR DESCRIPTION
Reviewed by @modethirteen and @JeremyRH 

The new settings parameter, `origin`, has special handling that causes a request header to be set in Plug.

This change refactors the inspection of the origin setting to use Uri directly (instead of a helper function in Plug), and adds tests to bring the code coverage back to 100%.