### PR TITLE
Linter cleanup and some bug fixes found during integration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,16 +1,12 @@
 {
   "globals": {
-
-    /* Jasmine */
-    "jasmine": false,
-    "describe": false,
-    "it": false,
-    "xdescribe": false,
-    "xit": false,
-    "expect": false,
-    "beforeEach": false,
-    "afterEach": false,
-    "Mocks": false,
+    "window": false,
+    "XMLHttpRequest": false,
+    "Mocks": true
+  },
+  env: {
+    es6: true,
+    jasmine: true
   },
   "parserOptions": {
     "ecmaVersion": 6,
@@ -89,6 +85,7 @@
     "no-label-var": 1,
     "no-shadow-restricted-names": 1,
     "no-shadow": 1,
+    "no-undef": 1,
     "no-undef-init": 1,
     "no-undefined": 1,
     "no-unused-vars": 1,

--- a/draft.js
+++ b/draft.js
@@ -22,7 +22,7 @@ import {PageBase} from './pageBase';
 import {pageModel} from './models/page.model';
 export class Draft extends PageBase {
     constructor(id = 'home', settings) {
-        super(id, settings);
+        super(id);
         this._plug = new Plug(settings).at('@api', 'deki', 'drafts', this._id);
     }
     deactivate() {

--- a/draftFile.js
+++ b/draftFile.js
@@ -16,10 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {fileModel} from './models/file.model';
+import {Plug} from './lib/plug';
+import {PageFileBase} from './pageFileBase';
 export class DraftFile extends PageFileBase {
-    constructor(pageId, filename) {
+    constructor(pageId, filename, settings) {
         super(pageId, filename);
-        this._plug = new Plug('@api', 'deki', 'drafts', this._pageId, 'files', this._filename);
+        this._plug = new Plug(settings).at('@api', 'deki', 'drafts', this._pageId, 'files', this._filename);
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*eslint-env node*/
 'use strict';
 
 var gulp = require('gulp');

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+/*eslint-env node*/
 module.exports = function(config) {
     'use strict';
     config.set({

--- a/models/relatedPages.model.js
+++ b/models/relatedPages.model.js
@@ -26,12 +26,10 @@ export let relatedPagesModel = {
             href: obj['@href'],
             pages: []
         };
-        if('page' in obj) {
-            let pages = modelHelper.getArray(obj.page);
-            pages.forEach((page) => {
-                parsed.pages.push(pageModel.parse(page));
-            });
-        }
+        let pages = modelHelper.getArray(obj.page);
+        pages.forEach((page) => {
+            parsed.pages.push(pageModel.parse(page));
+        });
         return parsed;
     }
 };

--- a/page.js
+++ b/page.js
@@ -27,7 +27,7 @@ import {pageRatingModel} from './models/pageRating.model';
 import {pageMoveModel} from './models/pageMove.model';
 export class Page extends PageBase {
     constructor(id = 'home', settings) {
-        super(id, settings);
+        super(id);
         this._plug = new Plug(settings).at('@api', 'deki', 'pages', this._id);
     }
     getInfo(params = {}) {
@@ -69,10 +69,6 @@ export class Page extends PageBase {
             throw new Error('Invalid rating supplied for the old rating');
         }
         return this._plug.at('ratings').withParams({ score: rating, previousScore: oldRating }).post(null, utility.textRequestType).then(pageRatingModel.parse);
-    }
-    logPageView() {
-        var viewPlug = new Plug().at('@api', 'deki', 'events', 'page-view', this._id).withParam('uri', encodeURIComponent(document.location.href));
-        return viewPlug.post(JSON.stringify({ _uri: document.location.href }), utility.jsonRequestType);
     }
     getHtmlTemplate(path, params = {}) {
         params.pageid = this._id;

--- a/pageBase.js
+++ b/pageBase.js
@@ -31,7 +31,7 @@ function _handleVirtualPage(error) {
     throw error;
 }
 export class PageBase {
-    constructor(id, settings) {
+    constructor(id) {
         if(this.constructor.name === 'PageBase') {
             throw new TypeError('PageBase must not be constructed directly.  Use one of Page() or Draft()');
         }
@@ -75,7 +75,7 @@ export class PageBase {
     getTags() {
         return this._plug.at('tags').get().then(pageTagsModel.parse);
     }
-    getDiff(revisionParam) {
+    getDiff() {
         throw new Error('Page.getDiff() is not impmemented');
     }
     getRelated() {

--- a/pageFile.js
+++ b/pageFile.js
@@ -16,10 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {fileModel} from './models/file.model';
+import {Plug} from './lib/plug';
+import {PageFileBase} from './PageFileBase';
 export class PageFile extends PageFileBase {
-    constructor(pageId, filename) {
+    constructor(pageId, filename, settings) {
         super(pageId, filename);
-        this._plug = new Plug('@api', 'deki', 'pages', this._pageId, 'files', this._filename);
+        this._plug = new Plug(settings).at('@api', 'deki', 'pages', this._pageId, 'files', this._filename);
     }
 }

--- a/test/mock/contextId.mock.js
+++ b/test/mock/contextId.mock.js
@@ -1,4 +1,4 @@
-/* eslint-disable quotes */
+
 window.Mocks = window.Mocks || {};
 Mocks.contextIdDefinitions = `{
     "context":[
@@ -9,8 +9,11 @@ Mocks.contextIdDefinitions = `{
 Mocks.contextIdDefinitionsSingle = `{
     "context":{"description":"","id":"foo"}
 }`;
-Mocks.contextIdDefinitionsEmpty = ``;
-Mocks.contextIdDefinition = `{"description":"Description of foo","id":"foo"}`;
+Mocks.contextIdDefinitionsEmpty = '';
+Mocks.contextIdDefinition = `{
+    "description":"Description of foo",
+    "id":"foo"
+}`;
 Mocks.contextMaps = `{
     "contextmap":[
         {
@@ -122,9 +125,24 @@ Mocks.contextMapSingleSingle = `{
     },
     "languages":{"language":"en-us"}
 }`;
-Mocks.contextMapsEmptySingleLanguage = `{"languages":{"language":"en-us"}}`;
-Mocks.contextMapsEmpty = `{"languages":{"language":["en-us","pt-br"]}}`;
-Mocks.contextMap = `{"@default":"false","@exists":"true","description":"Foo Description","id":"foo","language":"en-us","pageid":"273"}`;
+Mocks.contextMapsEmptySingleLanguage = `{
+    "languages":{
+        "language":"en-us"
+    }
+}`;
+Mocks.contextMapsEmpty = `{
+    "languages":{
+        "language":["en-us","pt-br"]
+    }
+}`;
+Mocks.contextMap = `{
+    "@default":"false",
+    "@exists":"true",
+    "description":"Foo Description",
+    "id":"foo",
+    "language":"en-us",
+    "pageid":"273"
+}`;
 Mocks.contextMapVerbose = `{
     "@default":"false",
     "@exists":"true",

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -303,13 +303,4 @@ describe('Page', () => {
             });
         });
     });
-    describe('page view logging', () => {
-        it('can log a page view', (done) => {
-            let page = new Page(123);
-            spyOn(Plug.prototype, 'post').and.returnValue(Promise.resolve({}));
-            page.logPageView().then(() => {
-                done();
-            });
-        });
-    });
 });

--- a/test/pageBase.test.js
+++ b/test/pageBase.test.js
@@ -19,8 +19,6 @@
 import {PageBase} from 'pageBase';
 describe('Page Base', () => {
     it('can not construct a PageBase object directly', () => {
-        expect(() => {
-            let pb = new PageBase();
-        }).toThrowError(TypeError);
+        expect(() => new PageBase()).toThrowError(TypeError);
     });
 });

--- a/test/userEvents.test.js
+++ b/test/userEvents.test.js
@@ -26,7 +26,7 @@ describe('User Events', () => {
         it('can construct a user events object', () => {
             let ue = new UserEvents();
             expect(ue).toBeDefined();
-            expect(() => UserEventManager()).toThrow();
+            expect(() => UserEvents()).toThrow();
         });
     });
     describe('functionality', () => {


### PR DESCRIPTION
* Added the `jasmine` environment to .eslintrc rather than listing every jasmine global
* Removed the `settings` param from the `PageBase` and `PageFileBase` constructors.  Adjusted the subclasses accordingly
* Removed Page.logPageView() as it is eventually going to be implemented in a `pageEvents` module
* Other miscellaneous linter adjustments