### PR TITLE
add 'type' constraint support for search

### DIFF
--- a/site.js
+++ b/site.js
@@ -40,6 +40,15 @@ function _buildSearchConstraints(params) {
             constraints.push('+tag:"' + utility.searchEscape(tag) + '"');
         });
     }
+    if('type' in params) {
+        var types = params.type;
+        if(typeof types === 'string' && (types)) {
+            types = types.split(',');
+        }
+        types.forEach((type) => {
+            constraints.push('+type:"' + utility.searchEscape(type) + '"');
+        });
+    }
     return '+(' + constraints.join(' ') + ')';
 }
 export class Site {
@@ -56,13 +65,16 @@ export class Site {
         }
         return locPlug.get();
     }
-    search({ page: page = 1, limit: limit = 10, tags: tags = '', q: q = '', path: path = '', recommendations = true } = {}) {
+    search({ page: page = 1, limit: limit = 10, tags: tags = '', type: type = '', q: q = '', path: path = '', recommendations = true } = {}) {
         let constraint = {};
         if(path !== '') {
             constraint.path = path;
         }
         if(tags !== '') {
             constraint.tags = tags;
+        }
+        if(type !== '') {
+            constraint.type = type;
         }
         let searchParams = {
             limit: limit,

--- a/site.js
+++ b/site.js
@@ -46,7 +46,7 @@ function _buildSearchConstraints(params) {
             types = types.split(',');
         }
         types.forEach((type) => {
-            constraints.push('+type:"' + utility.searchEscape(type) + '"');
+            constraints.push('+type:' + utility.searchEscape(type));
         });
     }
     return '+(' + constraints.join(' ') + ')';

--- a/test/site.test.js
+++ b/test/site.test.js
@@ -78,7 +78,7 @@ describe('Site API', () => {
         });
         it('can perform a search with some parameters', (done) => {
             spyOn(searchModel, 'parse').and.returnValue({});
-            sm.search({ page: 123, tags: [ 'abc', '123' ] }).then((e) => {
+            sm.search({ page: 123, tags: [ 'abc', '123' ], type: [ 'wiki', 'image' ] }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });
@@ -92,7 +92,7 @@ describe('Site API', () => {
         });
         it('can perform a search with all parameters', (done) => {
             spyOn(searchModel, 'parse').and.returnValue({});
-            sm.search({ path: '/foo/bar', tags: 'abc', page: 123, limit: 10, q: 'search term' }).then((e) => {
+            sm.search({ path: '/foo/bar', tags: 'abc', type: 'wiki', page: 123, limit: 10, q: 'search term' }).then((e) => {
                 expect(e).toBeDefined();
                 done();
             });


### PR DESCRIPTION
Add support for `type` constraint in search. Constraints are `wiki`, `document`, `image`, and `binary`.