### PR TITLE
Make sure a subpages array is always defined, name it even though the API field is

### DIFF
--- a/models/subpages.model.js
+++ b/models/subpages.model.js
@@ -26,23 +26,20 @@ let subpagesModel = {
             href: obj['@href'],
             subpages: []
         };
-        if('page.subpage' in obj) {
-            let subpages = modelHelper.getArray(obj['page.subpage']);
-            parsed.subpages = subpages.map((sp) => {
-                return {
-                    id: modelHelper.getInt(sp['@id']),
-                    href: sp['@href'],
-                    deleted: modelHelper.getBool(sp['@deleted']),
-                    hasSubpages: modelHelper.getBool(sp['@subpages']),
-                    dateCreated: modelHelper.getDate(sp['date.created']),
-                    language: sp.language,
-                    namespace: sp.namespace,
-                    path: modelHelper.getString(sp.path),
-                    title: sp.title,
-                    uriUi: sp['uri.ui']
-                };
-            });
-        }
+        parsed.subpages = modelHelper.getArray(obj['page.subpage']).map((sp) => {
+            return {
+                id: modelHelper.getInt(sp['@id']),
+                href: sp['@href'],
+                deleted: modelHelper.getBool(sp['@deleted']),
+                hasSubpages: modelHelper.getBool(sp['@subpages']),
+                dateCreated: modelHelper.getDate(sp['date.created']),
+                language: sp.language,
+                namespace: sp.namespace,
+                path: modelHelper.getString(sp.path),
+                title: sp.title,
+                uriUi: sp['uri.ui']
+            };
+        });
         return parsed;
     }
 };

--- a/models/subpages.model.js
+++ b/models/subpages.model.js
@@ -28,19 +28,19 @@ let subpagesModel = {
         };
         if('page.subpage' in obj) {
             let subpages = modelHelper.getArray(obj['page.subpage']);
-            subpages.forEach((sp) => {
-                parsed.subpages.push({
+            parsed.subpages = subpages.map((sp) => {
+                return {
                     id: modelHelper.getInt(sp['@id']),
                     href: sp['@href'],
                     deleted: modelHelper.getBool(sp['@deleted']),
-                    subpages: modelHelper.getBool(sp['@subpages']),
+                    hasSubpages: modelHelper.getBool(sp['@subpages']),
                     dateCreated: modelHelper.getDate(sp['date.created']),
                     language: sp.language,
                     namespace: sp.namespace,
                     path: modelHelper.getString(sp.path),
                     title: sp.title,
                     uriUi: sp['uri.ui']
-                });
+                };
             });
         }
         return parsed;

--- a/models/subpages.model.js
+++ b/models/subpages.model.js
@@ -23,8 +23,7 @@ let subpagesModel = {
         let parsed = {
             totalcount: modelHelper.getInt(obj['@totalcount']),
             count: modelHelper.getInt(obj['@count']),
-            href: obj['@href'],
-            subpages: []
+            href: obj['@href']
         };
         parsed.subpages = modelHelper.getArray(obj['page.subpage']).map((sp) => {
             return {

--- a/models/subpages.model.js
+++ b/models/subpages.model.js
@@ -23,13 +23,13 @@ let subpagesModel = {
         let parsed = {
             totalcount: modelHelper.getInt(obj['@totalcount']),
             count: modelHelper.getInt(obj['@count']),
-            href: obj['@href']
+            href: obj['@href'],
+            subpages: []
         };
         if('page.subpage' in obj) {
             let subpages = modelHelper.getArray(obj['page.subpage']);
-            parsed.pageSubpage = [];
             subpages.forEach((sp) => {
-                parsed.pageSubpage.push({
+                parsed.subpages.push({
                     id: modelHelper.getInt(sp['@id']),
                     href: sp['@href'],
                     deleted: modelHelper.getBool(sp['@deleted']),


### PR DESCRIPTION
Reviewed by @JeremyRH 

This code refactors the subpages model parsing so that the resulting object always has a `subpages` array entry.  This allows calling code to be able to assume the entry exists, and will have a 0-length array if there are no subpages.