### PR TITLE
Add 'type' parameter to the search model

### DIFF
--- a/models/search.model.js
+++ b/models/search.model.js
@@ -39,6 +39,7 @@ let searchModel = {
                     mime: result.mime,
                     rank: result.rank,
                     title: result.title,
+                    type: result.type,
                     uri: result.uri,
                     uriTrack: result['uri.track'],
                     page: {


### PR DESCRIPTION
Reviewed by @JeremyRH 

Added a missing field to the search result model for the result type.