### PR TITLE
MTP-2830: Use Number() to parse API response numbers (rather than parseInt())

### DIFF
--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -29,8 +29,8 @@ export let modelParser = {
             }
             return dateValue;
         },
-        integer(value) {
-            let intValue = parseInt(value, 10);
+        number(value) {
+            let intValue = Number(value);
             if(String(intValue) !== value) {
                 throw new Error('Failed converting to integer');
             }
@@ -76,6 +76,8 @@ export let modelParser = {
             result = parser(value);
         } else if(typeof transform === 'function') {
             result = transform(value);
+        } else {
+            throw new Error(`Invalid value used for the transform parameter while trying to convert ${value}`);
         }
         return result;
     },

--- a/models/contextMap.model.js
+++ b/models/contextMap.model.js
@@ -43,6 +43,6 @@ export let contextMapModel = [
     },
     {
         field: [ 'pageid', '#text' ],
-        transform: 'integer'
+        transform: 'number'
     }
 ];

--- a/models/event.model.js
+++ b/models/event.model.js
@@ -39,7 +39,7 @@ export let eventModel = [
     {
         field: '@version',
         name: 'version',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: [ 'request', '@id' ],
@@ -59,7 +59,7 @@ export let eventModel = [
             {
                 field: '@id',
                 name: 'id',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: 'name'
@@ -80,21 +80,21 @@ export let eventModel = [
             },
             {
                 field: 'limit',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: 'qid',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: 'totalrecommended',
                 name: 'totalRecommended',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: 'totalresults',
                 name: 'totalResults',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '_uri.host',

--- a/models/eventDetail.model.js
+++ b/models/eventDetail.model.js
@@ -21,7 +21,7 @@ export let eventDetailModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'summary',
@@ -38,7 +38,7 @@ export let eventDetailModel = [
             {
                 field: '@count',
                 name: 'count',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '@journaled',

--- a/models/eventList.model.js
+++ b/models/eventList.model.js
@@ -21,7 +21,7 @@ export let eventListModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@upto',
@@ -47,7 +47,7 @@ export let eventListModel = [
             {
                 field: '@count',
                 name: 'count',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '@detailid',

--- a/models/file.model.js
+++ b/models/file.model.js
@@ -22,17 +22,17 @@ export let fileModel = [
     {
         field: '@id',
         name: 'id',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@revision',
         name: 'revision',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@res-id',
         name: 'resId',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',
@@ -56,7 +56,7 @@ export let fileModel = [
     {
         field: '@res-contents-id',
         name: 'resContentsId',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'date.created',
@@ -79,7 +79,7 @@ export let fileModel = [
             {
                 field: '@size',
                 name: 'size',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '@href',

--- a/models/fileRevisions.model.js
+++ b/models/fileRevisions.model.js
@@ -21,12 +21,12 @@ export let fileRevisionsModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@totalcount',
         name: 'totalCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/models/groupList.model.js
+++ b/models/groupList.model.js
@@ -21,17 +21,17 @@ export let groupListModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@querycount',
         name: 'queryCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@totalcount',
         name: 'totalCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/models/page.model.js
+++ b/models/page.model.js
@@ -22,7 +22,7 @@ export let pageModel = [
     {
         field: '@id',
         name: 'id',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'title'
@@ -65,7 +65,7 @@ export let pageModel = [
     {
         field: '@revision',
         name: 'revision',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'date.created',

--- a/models/pageFiles.model.js
+++ b/models/pageFiles.model.js
@@ -21,17 +21,17 @@ export let pageFilesModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@offset',
         name: 'offset',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@totalcount',
         name: 'totalCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/models/pageMove.model.js
+++ b/models/pageMove.model.js
@@ -21,7 +21,7 @@ export let pageMoveModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'page',

--- a/models/pageProperties.model.js
+++ b/models/pageProperties.model.js
@@ -21,7 +21,7 @@ export let pagePropertiesModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/models/pageRating.model.js
+++ b/models/pageRating.model.js
@@ -20,7 +20,7 @@ export let pageRatingModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@date',
@@ -30,42 +30,42 @@ export let pageRatingModel = [
     {
         field: '@seated.count',
         name: 'seatedCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@unseated.count',
         name: 'unseatedCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@score',
         name: 'score',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@seated.score',
         name: 'seatedScore',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@unseated.score',
         name: 'unseatedScore',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@score.trend',
         name: 'scoreTrend',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@seated.score.trend',
         name: 'seatedScoreTrend',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@unseated.score.trend',
         name: 'unseatedScoreTrend',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'user.ratedby',
@@ -74,12 +74,12 @@ export let pageRatingModel = [
             {
                 field: '@id',
                 name: 'id',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '@score',
                 name: 'score',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '@date',

--- a/models/pageRatings.model.js
+++ b/models/pageRatings.model.js
@@ -21,7 +21,7 @@ export let pageRatingsModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/models/pageTags.model.js
+++ b/models/pageTags.model.js
@@ -20,7 +20,7 @@ export let pageTagsModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',
@@ -34,7 +34,7 @@ export let pageTagsModel = [
             {
                 field: '@id',
                 name: 'id',
-                transformer: 'integer'
+                transformer: 'number'
             },
             {
                 field: '@value',

--- a/models/relatedPages.model.js
+++ b/models/relatedPages.model.js
@@ -21,7 +21,7 @@ export let relatedPagesModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/models/search.model.js
+++ b/models/search.model.js
@@ -29,17 +29,17 @@ export let searchModel = [
     {
         field: '@querycount',
         name: 'queryCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@count.recommendations',
         name: 'recommendationCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: 'result',
@@ -59,14 +59,14 @@ export let searchModel = [
             },
             {
                 field: 'id',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: 'mime'
             },
             {
                 field: 'rank',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: 'title'
@@ -105,7 +105,7 @@ export let searchModel = [
                     {
                         field: '@count',
                         name: 'count',
-                        transform: 'integer'
+                        transform: 'number'
                     },
                     {
                         field: '@title',

--- a/models/subpages.model.js
+++ b/models/subpages.model.js
@@ -20,12 +20,12 @@ export let subpagesModel = [
     {
         field: '@totalcount',
         name: 'totalCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',
@@ -39,7 +39,7 @@ export let subpagesModel = [
             {
                 field: '@id',
                 name: 'id',
-                transform: 'integer'
+                transform: 'number'
             },
             {
                 field: '@href',

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -22,7 +22,7 @@ export let userModel = [
     {
         field: '@id',
         name: 'id',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@wikiid',

--- a/models/userActivity.model.js
+++ b/models/userActivity.model.js
@@ -21,7 +21,7 @@ export let userActivityModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@upto',

--- a/models/userList.model.js
+++ b/models/userList.model.js
@@ -21,17 +21,17 @@ export let userListModel = [
     {
         field: '@count',
         name: 'count',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@querycount',
         name: 'queryCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@totalcount',
         name: 'totalCount',
-        transform: 'integer'
+        transform: 'number'
     },
     {
         field: '@href',

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "karma-cli": "0.1.2",
     "karma-coverage": "0.5.5",
     "karma-jasmine": "0.3.8",
-    "karma-jspm": "2.0.2",
+    "karma-jspm": "2.1.0",
     "karma-phantomjs-launcher": "1.0.0",
     "karma-sourcemap-loader": "0.3.7",
     "phantomjs-prebuilt": "2.1.5"

--- a/test/modelParser.test.js
+++ b/test/modelParser.test.js
@@ -42,13 +42,15 @@ describe('Model Parser', () => {
             expect(err).toBeDefined();
         });
         it('returns a valid integer', () => {
-            let toInteger = modelParser.to.integer('5');
+            let toInteger = modelParser.to.number('5');
             expect(toInteger).toBe(5);
+            let toFloat = modelParser.to.number('3.6');
+            expect(toFloat).toBe(3.6);
         });
         it('thows converting to integer', () => {
             let err;
             try {
-                modelParser.to.integer('55-55');
+                modelParser.to.number('55-55');
             } catch(e) {
                 err = e;
             }
@@ -122,7 +124,7 @@ describe('Model Parser', () => {
     describe('Transform Value', () => {
         it('returns the value transformed by a type converter', () => {
             let value = '5';
-            let transform = 'integer';
+            let transform = 'number';
             let result = modelParser.transformValue(value, transform);
             expect(result).toBe(5);
         });
@@ -140,6 +142,9 @@ describe('Model Parser', () => {
             ];
             let result = modelParser.transformValue(value, transform);
             expect(result).toEqual({ ids: [ 5 ] });
+        });
+        it('can throw if an invalid transform is passed in', () => {
+            expect(() => modelParser.transformValue('foo', 100)).toThrow();
         });
     });
     describe('Create Parser', () => {

--- a/test/permissionsModel.test.js
+++ b/test/permissionsModel.test.js
@@ -19,27 +19,40 @@
 import { permissionsModel } from '../models/permissions.model';
 describe('Permissions Model', () => {
     it('returns the parsed operations', () => {
-        let operations = 'foo,bar';
+        let operations1 = 'foo,bar';
+        let operations2 = 100;
         permissionsModel.forEach((propertyModel) => {
             if(typeof propertyModel.transform === 'function' && propertyModel.field[0] === 'operations') {
-                operations = propertyModel.transform(operations);
+                operations1 = propertyModel.transform(operations1);
+                operations2 = propertyModel.transform(operations2);
             }
         });
-        expect(operations).toEqual([ 'foo', 'bar' ]);
+        expect(operations1).toEqual([ 'foo', 'bar' ]);
+        expect(operations2).toEqual([]);
     });
     it('returns the parsed role', () => {
+        let role0 = 100;
         let role1 = {
             '#text': 'role name',
             '@id': '5',
             '@href': 'href'
         };
         let role2 = 'role name';
+        let role3 = {
+            '@id': '5',
+            '@href': 'href'
+        };
+        let role4 = {};
         permissionsModel.forEach((propertyModel) => {
             if(typeof propertyModel.transform === 'function' && propertyModel.field === 'role') {
+                role0 = propertyModel.transform(role0);
                 role1 = propertyModel.transform(role1);
                 role2 = propertyModel.transform(role2);
+                role3 = propertyModel.transform(role3);
+                role4 = propertyModel.transform(role4);
             }
         });
+        expect(role0).toEqual({});
         expect(role1).toEqual({
             name: 'role name',
             id: 5,
@@ -48,5 +61,7 @@ describe('Permissions Model', () => {
         expect(role2).toEqual({
             name: 'role name'
         });
+        expect(role3).toEqual({ id: 5, href: 'href' });
+        expect(role4).toEqual({});
     });
 });


### PR DESCRIPTION
Ticket: https://mindtouch.myjetbrains.com/youtrack/issue/MTP-2830
Reviewed by @JeremyRH 

Summary:
- Change the parser logic to look for `number` as a transformer instead of `integer`
- Throw when an invalid transformer is in the model
- Change all models to use `number`
- Update/enhance tests