### PR TITLE
MTP-2840: Don't include path in the search constraint if it's just a slash

### DIFF
--- a/site.js
+++ b/site.js
@@ -99,7 +99,7 @@ export class Site {
      */
     search({ page: page = 1, limit: limit = 10, tags: tags = '', type: type = '', q: q = '', path: path = '', recommendations = true } = {}) {
         let constraint = {};
-        if(path !== '') {
+        if(path !== '' && path !== '/') {
             constraint.path = path;
         }
         if(tags !== '') {


### PR DESCRIPTION
Ticket: https://mindtouch.myjetbrains.com/youtrack/issue/MTP-2840
Reviewed by @JeremyRH 

This checks to see if the search path is '/', and excludes the `path.ancestor` field from the constraint.