### PR TITLE
Add JSPM helper fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Core JavaScript API for MindTouch",
   "license": "Apache-2.0",
   "main": false,
+  "format": "esm",
   "repository": {
     "type": "git",
     "url": "https://github.com/MindTouch/martian"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/MindTouch/martian",
   "dependencies": {
-    "mindtouch-http": "git+https://github.com/aaronmars/mindtouch-http.js.git"
+    "mindtouch-http": "git+https://github.com/MindTouch/mindtouch-http.js.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/MindTouch/martian",
   "dependencies": {
-    "mindtouch-http": "git+https://github.com/MindTouch/mindtouch-http.js.git"
+    "mindtouch-http": "git+https://github.com/aaronmars/mindtouch-http.js.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "main": false,
   "format": "esm",
+  "registry": "npm",
   "repository": {
     "type": "git",
     "url": "https://github.com/MindTouch/martian"


### PR DESCRIPTION
Add the `format` and `registry` fields to help with clients that want to use this library in a JSPM environment.