### PR TITLE
Update the dependency to use the initial release of mindtouch-http.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/MindTouch/martian",
   "dependencies": {
-    "mindtouch-http": "git+https://github.com/MindTouch/mindtouch-http.js.git"
+    "mindtouch-http": "git+https://github.com/MindTouch/mindtouch-http.js.git#0.0.0"
   }
 }


### PR DESCRIPTION
MindTouch/mindtouch-http.js@0.0.0 has been released.  Use this version for martian.