### PR TITLE
Add content type param to Page.setOverview()... Update some packages

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -1,0 +1,16 @@
+/* eslint-env jasmine, jest */
+jest.unmock('../api');
+import { Api } from '../api';
+
+describe('API Module', () => {
+    let api = null;
+    beforeEach(() => {
+        api = new Api();
+    });
+    it('can verify a successful HTTP request', () => {
+        return api.http();
+    });
+    it('can verify a successful F1 request', () => {
+        return api.f1();
+    });
+});

--- a/jest-jsdom.json
+++ b/jest-jsdom.json
@@ -24,5 +24,9 @@
         "lib/tokenHelper.js": true,
         "lib/utility.js": true
     },
-    "unmockedModulePathPatterns": [ "<rootDir>/models/" ]
+    "unmockedModulePathPatterns": [ "<rootDir>/models/" ],
+    "testPathIgnorePatterns": [
+        "<rootDir>/node_modules/",
+        "<rootDir>/models/__tests__/mock/"
+    ]
 }

--- a/jest-node.json
+++ b/jest-node.json
@@ -25,5 +25,9 @@
         "lib/tokenHelper.js": true,
         "lib/utility.js": true
     },
-    "unmockedModulePathPatterns": [ "<rootDir>/models/" ]
+    "unmockedModulePathPatterns": [ "<rootDir>/models/" ],
+    "testPathIgnorePatterns": [
+        "<rootDir>/node_modules/",
+        "<rootDir>/models/__tests__/mock/"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "inspect": "eslint ./**/*.js"
   },
   "devDependencies": {
-    "babel-jest": "12.1.0",
-    "babel-polyfill": "6.9.1",
-    "babel-preset-es2015": "6.9.0",
-    "eslint": "2.11.1",
+    "babel-jest": "14.1.0",
+    "babel-polyfill": "6.13.0",
+    "babel-preset-es2015": "6.13.2",
+    "eslint": "3.2.2",
     "eslint-config-mindtouch": "1.0.0",
-    "jest-cli": "12.1.1"
+    "jest-cli": "14.1.0"
   },
   "author": "MindTouch",
   "bugs": {

--- a/pageBase.js
+++ b/pageBase.js
@@ -43,7 +43,7 @@ export class PageBase {
             contentsParams[key] = params[key];
         });
         let pageEditModelParser = modelParser.createParser(pageEditModel);
-        return this._plug.at('contents').withParams(contentsParams).post(contents, 'text/plain; charset=utf-8').then((r) => r.json()).then(pageEditModelParser);
+        return this._plug.at('contents').withParams(contentsParams).post(contents, utility.textRequestType).then((r) => r.json()).then(pageEditModelParser);
     }
     getFiles(params = {}) {
         let pageFilesModelParser = modelParser.createParser(pageFilesModel);
@@ -61,7 +61,7 @@ export class PageBase {
             return Promise.reject(new Error('No overview body was supplied'));
         }
         let request = `<overview>${options.body}</overview>`;
-        return this._plug.at('overview').put(request);
+        return this._plug.at('overview').put(request, utility.xmlRequestType);
     }
     getTags() {
         let pageTagsModelParser = modelParser.createParser(pageTagsModel);


### PR DESCRIPTION
Reviewed by @JeremyRH 

In pageBase.js, the mime parameter in the post() call in setContents() was a hardcoded string.  This was changed to the pre-defined `utility.textRequestType`.  The mime type parameter in the put() call in setOverview() was not set at all, and needed to be set to `utility.xmlRequestType`

I also updated some packages and added some tests.