### PR TITLE
MTP-4402: Fix case sensitivity in JSPM dependencies

### DIFF
--- a/models/pageProperty.model.js
+++ b/models/pageProperty.model.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import { pageModel } from './page.model';
-import { propertyContentsModel } from './propertyContents.model'
+import { propertyContentsModel } from './propertyContents.model';
 export let pagePropertyModel = [
     {
         field: '@revision',

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "homepage": "https://github.com/MindTouch/martian",
   "dependencies": {
-    "mindtouch-http": "git+https://github.com/MindTouch/mindtouch-http.js.git#0.2.0"
+    "mindtouch-http": "git+https://github.com/mindtouch/mindtouch-http.js.git#0.2.0"
   }
 }


### PR DESCRIPTION
Ticket: https://mindtouch.myjetbrains.com/youtrack/issue/MTP-4402
Reviewed by: @JeremyRH 

The dependencies for JSPM are case-sensitive.  Moving to lower-case for the mindtouch-http.js declaration.