### PR TITLE
Draft/encoding enhancements

### DIFF
--- a/draft.js
+++ b/draft.js
@@ -37,6 +37,14 @@ export class Draft extends PageBase {
     publish() {
         return this._plug.at('publish').post();
     }
+
+    /**
+     * Unpublish a live page and create a draft out of it.
+     * @returns {Promise.<pageModel>} - A Promise that, when resolved, yields a {@link pageModel} for the unpublished page.
+     */
+    unpublish() {
+        return this._plug.at('unpublish').post().then(modelParser.createParser(pageModel));
+    }
 }
 
 /**

--- a/file.js
+++ b/file.js
@@ -20,6 +20,7 @@ export class File {
         this._id = id;
         this._settings = settings;
         this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'files', id);
+        this._progressPlug = new progressPlugFactory.ProgressPlug(settings.host, settings.plugConfig).at('@api', 'deki', 'files', id);
     }
 
     /**
@@ -64,8 +65,14 @@ export class File {
      * @param { function } progress - A function that is called to indicate upload progress before the upload is complete.
      */
     addRevision(file, filename, progress) {
-        const progressPlug = new progressPlugFactory.ProgressPlug(this._settings.host, this._settings.plugConfig).at('@api', 'deki', 'files', this._id);
         const progressInfo = { callback: progress, size: file.size };
-        return progressPlug.at(utility.getResourceId(filename)).put(file, file.type, progressInfo).then((r) => JSON.parse(r.responseText)).then(modelParser.createParser(fileModel));
+        return this._progressPlug.at(utility.getResourceId(filename)).put(file, file.type, progressInfo).then((r) => JSON.parse(r.responseText)).then(modelParser.createParser(fileModel));
+    }
+}
+export class FileDraft extends File {
+    constructor(id, settings = new Settings()) {
+        super(id, settings);
+        this._plug = this._plug.withParam('draft', 'true');
+        this._progressPlug = this._progressPlug.withParam('draft', 'true');
     }
 }

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -17,10 +17,29 @@
  * limitations under the License.
  */
 import 'core-js/modules/es6.string.includes';
-export let utility = {
+
+const _htmlEscapeChars = {
+    '¢': 'cent',
+    '£': 'pound',
+    '¥': 'yen',
+    '€': 'euro',
+    '©': 'copy',
+    '®': 'reg',
+    '<': 'lt',
+    '>': 'gt',
+    '"': 'quot',
+    '&': 'amp',
+    '\'': '#39'
+};
+const _regexString = new RegExp(`${Object.keys(_htmlEscapeChars).reduce((prev, key) => `${prev}${key}`, '[')}]`, 'g');
+
+export const utility = {
     xmlRequestType: 'application/xml; charset=utf-8',
     textRequestType: 'text/plain; charset=utf-8',
     jsonRequestType: 'application/json; charset=utf-8',
+    escapeHTML(unescaped = '') {
+        return unescaped.replace(_regexString, (m) => '&' + _htmlEscapeChars[m] + ';');
+    },
     searchEscape(query) {
         let result = query.toString();
         let charArr = [ '\\', '+', '-', '&', '|', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':' ];

--- a/pageBase.js
+++ b/pageBase.js
@@ -64,7 +64,7 @@ export class PageBase {
         if(!('body' in options)) {
             return Promise.reject(new Error('No overview body was supplied'));
         }
-        let request = `<overview>${options.body}</overview>`;
+        let request = `<overview>${utility.escapeHTML(options.body)}</overview>`;
         return this._plug.at('overview').put(request, utility.xmlRequestType);
     }
     getTags() {


### PR DESCRIPTION
Reviewed by @JeremyRH 

- Add Draft.prototype.unpublish()
- Add FileDraft class so files on draft pages can be manipulated
- Add HTML escaping to utility and use it in the page overview setter