### PR TITLE
Bump versions for release 1.6.4 and mindtouch-http.js@1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindtouch-martian",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Core JavaScript API for MindTouch",
   "license": "Apache-2.0",
   "main": false,
@@ -32,6 +32,6 @@
   },
   "homepage": "https://github.com/MindTouch/martian",
   "dependencies": {
-    "mindtouch-http": "git+https://github.com/mindtouch/mindtouch-http.js.git#1.0.0"
+    "mindtouch-http": "git+https://github.com/mindtouch/mindtouch-http.js.git#1.0.2"
   }
 }


### PR DESCRIPTION
mindtouch-http.js@1.0.2 contains a bugfix for file upload progress reporting.  This gets that version as a dependency in martian@1.6