### PR TITLE
Changes to search API and fixes for defaults in model parser

### DIFF
--- a/__tests__/site.test.js
+++ b/__tests__/site.test.js
@@ -59,7 +59,7 @@ describe('Site API', () => {
             return sm.search();
         });
         it('can perform a search with some parameters', () => {
-            return sm.search({ page: 123, tags: [ 'abc', '123' ], type: [ 'wiki', 'image' ] });
+            return sm.search({ tags: [ 'abc', '123' ], type: [ 'wiki', 'image' ] });
         });
         it('can perform a search with some other parameters', () => {
             return sm.search({ path: 'foo/bar', q: 'search thing' });
@@ -68,7 +68,7 @@ describe('Site API', () => {
             return sm.search({ q: 'search term', namespaces: 'template' });
         });
         it('can perform a search with all parameters', () => {
-            return sm.search({ path: '/foo/bar', tags: 'abc', type: 'wiki', page: 123, limit: 10, q: 'search term', namespaces: [ 'main', 'template' ] });
+            return sm.search({ path: '/foo/bar', tags: 'abc', type: 'wiki', offset: 123, limit: 10, q: 'search term', namespaces: [ 'main', 'template' ] });
         });
     });
     describe('site tags operations', () => {

--- a/lib/__tests__/modelParser.test.js
+++ b/lib/__tests__/modelParser.test.js
@@ -63,18 +63,16 @@ describe('Model Parser', () => {
     });
     describe('Valid Check', () => {
         it('returns true', () => {
-            let isTrue = modelParser.isValid(0) && modelParser.isValid(false) && modelParser.isValid([]) && modelParser.isValid('');
-            expect(isTrue).toBe(true);
+            expect(modelParser.isValid(0) && modelParser.isValid(false) && modelParser.isValid('') && modelParser.isValid(NaN)).toBe(true);
         });
         it('returns false', () => {
-            let isFalse = modelParser.isValid() || modelParser.isValid(null) || modelParser.isValid(NaN);
-            expect(isFalse).toBe(false);
+            const s = undefined;  // eslint-disable-line no-undefined
+            expect(modelParser.isValid(s)).toBe(false);
         });
     });
     describe('Force Array', () => {
         it('returns an empty array', () => {
-            let forcedArr = modelParser.forceArray();
-            expect(forcedArr).toEqual([]);
+            expect(modelParser.forceArray()).not.toBeDefined();
         });
         it('returns an array with a value', () => {
             let forcedArr = modelParser.forceArray(5);

--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -41,11 +41,11 @@ export let modelParser = {
         }
     },
     isValid(value) {
-        return value === 0 || value === false || value === '' || Boolean(value);
+        return typeof value !== 'undefined';
     },
     forceArray(value) {
         if(!modelParser.isValid(value)) {
-            return [];
+            return;
         }
         return Array.isArray(value) ? value : [ value ];
     },

--- a/models/search.model.js
+++ b/models/search.model.js
@@ -19,10 +19,11 @@
 import { pageModel } from './page.model.js';
 export const searchModel = [
     { field: '@ranking', name: 'ranking' },
-    { field: '@queryid', name: 'queryId' },
+    { field: '@queryid', name: 'queryId', transform: 'number' },
     { field: '@querycount', name: 'queryCount', transform: 'number' },
     { field: '@count.recommendations', name: 'recommendationCount', transform: 'number' },
     { field: '@count', name: 'count', transform: 'number' },
+    { field: 'parsedQuery' },
     {
         field: 'result',
         name: 'results',
@@ -38,7 +39,17 @@ export const searchModel = [
             { field: 'type' },
             { field: 'uri' },
             { field: 'uri.track', name: 'uriTrack' },
-            { field: 'page', transform: pageModel }
+            { field: 'page', transform: pageModel },
+            { field: 'preview' },
+            {
+                field: 'tag',
+                name: 'tags',
+                transform(value) {
+                    if(value) {
+                        return value.split('\n');
+                    }
+                }
+            }
         ]
     },
     {

--- a/page.js
+++ b/page.js
@@ -50,8 +50,7 @@ export class Page extends PageBase {
      * @returns {Promise.<subpagesModel>} - A Promise that, when resolved, yields a {@link subpagesModel} containing the basic page information.
      */
     getSubpages(params) {
-        let subpagesModelParser = modelParser.createParser(subpagesModel);
-        return this._plug.at('subpages').withParams(params).get().then((r) => r.json()).then(subpagesModelParser);
+        return this._plug.at('subpages').withParams(params).get().then((r) => r.json()).then(modelParser.createParser(subpagesModel));
     }
 
     /**
@@ -190,8 +189,7 @@ export class PageManager {
      * @returns {Promise.<pageRatingsModel>} - A Promise that, when resolved, yields a {@link pageRatingsModel} object with the ratings information.
      */
     getRatings(pageIds) {
-        var ratingsPlug = this._plug.at('pages', 'ratings').withParams({ pageids: pageIds.join(',') });
-        let pageRatingsModelParser = modelParser.createParser(pageRatingsModel);
-        return ratingsPlug.get().then((r) => r.json()).then(pageRatingsModelParser);
+        const ratingsPlug = this._plug.at('ratings').withParams({ pageids: pageIds.join(',') });
+        return ratingsPlug.get().then((r) => r.json()).then(modelParser.createParser(pageRatingsModel));
     }
 }

--- a/site.js
+++ b/site.js
@@ -124,8 +124,8 @@ export class Site {
     /**
      * Perform a search across the site.
      * This function takes a single parameter with the following options.
-     * @param {Number} [page=1] The paginated page number offset to return.
      * @param {Number} [limit=10] - Limit search results to the specified number of items per paginated page.
+     * @param {Number} [offset=10] - The index in the total query results at which to begin the returned result set.
      * @param {String|Array} [tags=''] - A comma-separated list or array of tags to constrain search results to items containing one of the tags.
      * @param {String|Array} [type=''] - Type or types to filter the results in a comma delimited list or an array.  Valid types: `wiki`, `document`, `image`, `binary`
      * @param {String} [q=''] - Search keywords or advanced search syntax.
@@ -134,8 +134,8 @@ export class Site {
      * @param {Boolean} [recommendations=true] - `true` to include recommended search results based off site configuration. `false` to suppress them.
      * @returns {Promise.<searchModel>} - A Promise that, when resolved, yields the results from the search in a {@link searchModel}.
      */
-    search({ page = 1, limit = 10, tags = '', type = '', q = '', path = '', recommendations = true, namespaces = 'main' } = {}) {
-        let constraint = {};
+    search({ limit = 10, offset = 0, q = '', path = '', recommendations = true, tags = '', type = '', namespaces = 'main' } = {}) {
+        const constraint = {};
         if(path !== '' && path !== '/') {
             constraint.path = path;
         }
@@ -146,17 +146,15 @@ export class Site {
             constraint.type = type;
         }
         constraint.namespaces = namespaces;
-        let searchParams = {
+        const searchParams = {
             limit: limit,
-            page: page,
-            offset: (parseInt(limit, 10) * (parseInt(page, 10) - 1)),
+            offset: offset,
             sortBy: '-date,-rank',
             q: q,
             summarypath: encodeURI(path),
             constraint: _buildSearchConstraints(constraint),
             recommendations: recommendations
         };
-        let searchModelParser = modelParser.createParser(searchModel);
-        return this.plug.at('query').withParams(searchParams).get().then((r) => r.json()).then(searchModelParser);
+        return this.plug.at('query').withParams(searchParams).get().then((r) => r.json()).then(modelParser.createParser(searchModel));
     }
 }


### PR DESCRIPTION
Reviewed by @JeremyRH 

- Change modelParser to only consider `undefined` an invalid value
- Change modelParser to return `undefined` instead of an empty array in forceArray()
- Search model:
  - `queryId` should be a number
  - Add `preview` field
  - Add tags parsing
  - Add `parsedQuery` field
- Fix a bug in Page.prototype.getRatings where 'pages' was being added a 2nd time
- Site.prototype.search:
  - Remove `page` parameter since the API has no concept of this.
  - Add `offset` instead so martian clients can still implement paging with offset+limit