### PR TITLE
Allow models to pre-process data before they are run through the generic model parser

### DIFF
--- a/lib/__tests__/modelParser.test.js
+++ b/lib/__tests__/modelParser.test.js
@@ -72,7 +72,8 @@ describe('Model Parser', () => {
     });
     describe('Force Array', () => {
         it('returns an empty array', () => {
-            expect(modelParser.forceArray()).not.toBeDefined();
+            expect(modelParser.forceArray()).toEqual([]);
+            expect(modelParser.forceArray('')).toEqual([]);
         });
         it('returns an array with a value', () => {
             let forcedArr = modelParser.forceArray(5);
@@ -174,6 +175,16 @@ describe('Model Parser', () => {
             ];
             let parser = modelParser.createParser(model);
             expect(() => parser(5)).toThrow();
+        });
+        it('creates a parser with `model` and `preProcessor` fields', () => {
+            const complexModel = {
+                preProcessor(v) {
+                    return v;
+                },
+                model: [ { field: 'context' } ]
+            };
+            const parser = modelParser.createParser(complexModel);
+            expect(parser({ context: 'foo' })).toBeDefined();
         });
     });
 });

--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -44,8 +44,8 @@ export let modelParser = {
         return typeof value !== 'undefined';
     },
     forceArray(value) {
-        if(!modelParser.isValid(value)) {
-            return;
+        if(!modelParser.isValid(value) || value === '') {
+            return [];
         }
         return Array.isArray(value) ? value : [ value ];
     },
@@ -64,13 +64,28 @@ export let modelParser = {
             return modelParser.getValue(obj[currentField], ...fields);
         }
     },
+    processModelAndData(model, data) {
+        let preProcessor = null;
+        let dataModel = null;
+        if(typeof model === 'object' && model.model) {
+            preProcessor = model.preProcessor;
+            dataModel = model.model;
+        } else {
+            dataModel = model;
+        }
+        if(preProcessor !== null && typeof preProcessor === 'function') {
+            data = preProcessor(data);
+        }
+        return [ dataModel, data ];
+    },
     transformValue(value, transform) {
         let result = value;
         if(typeof transform === 'string') {
             result = modelParser.to[transform](value);
-        } else if(Array.isArray(transform)) {
-            let parser = modelParser.createParser(transform, { ignoreUnparsed: true });
-            result = parser(value);
+        } else if(Array.isArray(transform) || transform.model) {
+            const [ processedModel, processedData ] = modelParser.processModelAndData(transform, value);
+            let parser = modelParser.createParser(processedModel, { ignoreUnparsed: true });
+            result = parser(processedData);
         } else if(typeof transform === 'function') {
             result = transform(value);
         } else {
@@ -84,11 +99,12 @@ export let modelParser = {
         }
         let fields = modelParser.forceArray(field);
         let value = modelParser.getValue(data, ...fields);
-        if(isArray) {
-            value = modelParser.forceArray(value);
-        }
         if(constructTransform && typeof constructTransform === 'function') {
             transform = constructTransform(value);
+            [ transform, value ] = modelParser.processModelAndData(transform, value);
+        }
+        if(isArray) {
+            value = modelParser.forceArray(value);
         }
         if(transform && modelParser.isValid(value) || typeof transform === 'function') {
             if(isArray) {
@@ -110,14 +126,15 @@ export let modelParser = {
             if(data === '') {
                 return {};
             }
+            const [ processedModel, processedData ] = modelParser.processModelAndData(model, data);
             let jsonData = null;
             let dataProps = null;
             if(!options.ignoreUnparsed) {
-                jsonData = JSON.stringify(data);
-                dataProps = new PropWatcher(data);
+                jsonData = JSON.stringify(processedData);
+                dataProps = new PropWatcher(processedData);
             }
             const parsedObj = {};
-            model.forEach((propertyModel) => modelParser.parseProperty(data, parsedObj, propertyModel));
+            processedModel.forEach((propertyModel) => modelParser.parseProperty(processedData, parsedObj, propertyModel));
             if(!options.ignoreUnparsed) {
                 parsedObj._unparsedProperties = dataProps.getUnaccessed();
                 dispatchEvent('martian:unparsed-data', {

--- a/models/__tests__/models.test.js
+++ b/models/__tests__/models.test.js
@@ -67,7 +67,6 @@ const learningPathModelParser = modelParser.createParser(learningPathModel);
 const learningPathsModelParser = modelParser.createParser(learningPathsModel);
 const pageModelParser = modelParser.createParser(pageModel);
 const pageContentsModelParser = modelParser.createParser(pageContentsModel);
-const pageTreeModelParser = modelParser.createParser(pageTreeModel);
 const pageEditModelParser = modelParser.createParser(pageEditModel);
 const pageFilesModelParser = modelParser.createParser(pageFilesModel);
 const pageMoveModelParser = modelParser.createParser(pageMoveModel);
@@ -159,7 +158,7 @@ describe('Models', () => {
     });
     describe('Page tree model', () => {
         it('can parse page tree info', () => {
-            expect(pageTreeModelParser(Mocks.pageTree)).toBeDefined();
+            expect(modelParser.createParser(pageTreeModel)(Mocks.pageTree)).toBeDefined();
         });
     });
     describe('Page edit model', () => {

--- a/models/page.model.js
+++ b/models/page.model.js
@@ -54,6 +54,5 @@ const pageModel = [
         }
     }
 ];
-pageModel.push({ field: [ 'subpages', 'page' ], name: 'subpages', isArray: true, transform: pageModel });
 pageModel.push({ field: 'page.parent', name: 'pageParent', transform: pageModel });
 export { pageModel };

--- a/models/pageTree.model.js
+++ b/models/pageTree.model.js
@@ -16,10 +16,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { pageModel } from './page.model.js';
-export let pageTreeModel = [
-    {
-        field: 'page',
-        transform: pageModel
+export const pageTreeModel = {
+    preProcessor(data) {
+        if(data.page) {
+            return data.page;
+        }
+    },
+    model: [
+        { field: '@id', name: 'id', transform: 'number' },
+        { field: '@guid', name: 'guid' },
+        { field: '@draft.state', name: 'draftState' },
+        { field: '@href', name: 'href' },
+        { field: '@deleted', name: 'deleted', transform: 'boolean' },
+        { field: 'date.created', name: 'dateCreated', transform: 'date' },
+        { field: 'namespace', name: 'namespace' },
+        { field: [ 'path', '#text' ], name: 'path' },
+        { field: 'title', name: 'title' },
+        { field: 'uri.ui', name: 'uri' }
+    ]
+};
+pageTreeModel.model.push({
+    field: 'subpages',
+    isArray: true,
+    constructTransform(val) {
+        if(val.page) {
+            return pageTreeModel;
+        }
     }
-];
+});


### PR DESCRIPTION
Reviewed by @killsunday 

This adds the notion of a pre-processor in the model spec.  This is for the rare cases where the data returned by the API needs some tweaking before the standard model parsing and transforming is applied.

Currently, this is only used in the page Tree model.