### PR TITLE
Refactor page rating to use 1/0/null as rating values

### DIFF
--- a/__tests__/page.test.js
+++ b/__tests__/page.test.js
@@ -108,6 +108,9 @@ describe('Page', () => {
         it('can rate a page', () => {
             return page.rate(1);
         });
+        it('can rate a page; sending in the old rating', () => {
+            return page.rate(1, 0);
+        });
         it('can reset a page rating implicitly', () => {
             return page.rate();
         });

--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -33,6 +33,9 @@ export let modelParser = {
             return dateValue;
         },
         number(value) {
+            if(value === '') {
+                return null;
+            }
             let intValue = Number(value);
             if(isNaN(intValue) || (value !== '' && String(intValue) !== value)) {
                 throw new Error('Failed converting to integer');

--- a/models/pageRating.model.js
+++ b/models/pageRating.model.js
@@ -17,84 +17,27 @@
  * limitations under the License.
  */
 export let pageRatingModel = [
-    {
-        field: '@count',
-        name: 'count',
-        transform: 'number'
-    },
-    {
-        field: '@date',
-        name: 'date',
-        transform: 'date'
-    },
-    {
-        field: '@seated.count',
-        name: 'seatedCount',
-        transform: 'number'
-    },
-    {
-        field: '@unseated.count',
-        name: 'unseatedCount',
-        transform: 'number'
-    },
-    {
-        field: '@score',
-        name: 'score',
-        transform: 'number'
-    },
-    {
-        field: '@seated.score',
-        name: 'seatedScore',
-        transform: 'number'
-    },
-    {
-        field: '@unseated.score',
-        name: 'unseatedScore',
-        transform: 'number'
-    },
-    {
-        field: '@score.trend',
-        name: 'scoreTrend',
-        transform: 'number'
-    },
-    {
-        field: '@seated.score.trend',
-        name: 'seatedScoreTrend',
-        transform: 'number'
-    },
-    {
-        field: '@unseated.score.trend',
-        name: 'unseatedScoreTrend',
-        transform: 'number'
-    },
+    { field: '@date', name: 'date', transform: 'date' },
+    { field: '@count', name: 'count', transform: 'number' },
+    { field: '@seated.count', name: 'seatedCount', transform: 'number' },
+    { field: '@unseated.count', name: 'unseatedCount', transform: 'number' },
+    { field: '@anonymous.count', name: 'anonymousCount', transform: 'number' },
+    { field: '@score', name: 'score', transform: 'number' },
+    { field: '@seated.score', name: 'seatedScore', transform: 'number' },
+    { field: '@unseated.score', name: 'unseatedScore', transform: 'number' },
+    { field: '@anonymous.score', name: 'anonymousScore', transform: 'number' },
+    { field: '@score.trend', name: 'scoreTrend', transform: 'number' },
+    { field: '@seated.score.trend', name: 'seatedScoreTrend', transform: 'number' },
+    { field: '@unseated.score.trend', name: 'unseatedScoreTrend', transform: 'number' },
     {
         field: 'user.ratedby',
         name: 'userRatedBy',
         transform: [
-            {
-                field: '@id',
-                name: 'id',
-                transform: 'number'
-            },
-            {
-                field: '@score',
-                name: 'score',
-                transform: 'number'
-            },
-            {
-                field: '@date',
-                name: 'date',
-                transform: 'date'
-            },
-            {
-                field: '@href',
-                name: 'href'
-            },
-            {
-                field: '@seated',
-                name: 'seated',
-                transform: 'boolean'
-            }
+            { field: '@id', name: 'id', transform: 'number' },
+            { field: '@score', name: 'score', transform: 'number' },
+            { field: '@date', name: 'date', transform: 'date' },
+            { field: '@href', name: 'href' },
+            { field: '@seated', name: 'seated', transform: 'boolean' }
         ]
     }
 ];

--- a/page.js
+++ b/page.js
@@ -86,27 +86,29 @@ export class Page extends PageBase {
      * @returns {Promise.<pageRatingModel>} - A Promise that, when resolved, yields a {@link pageRatingModel} containing the rating information.
      */
     getRating() {
-        let pageRatingModelParser = modelParser.createParser(pageRatingModel);
-        return this._plug.at('ratings').get().then((r) => r.json()).then(pageRatingModelParser);
+        return this._plug.at('ratings').get().then((r) => r.json()).then(modelParser.createParser(pageRatingModel));
     }
 
     /**
      * Set the rating for the page.
-     * @param {String} [rating=''] - The new rating for the page.
-     * @param {String} [oldRating=''] - The old rating for the page that is being replaced by {@see rating}.
+     * @param {Number|null} [rating=null] - The new rating for the page.
+     * @param {Number|null} [oldRating=null] - The old rating for the page that is being replaced by {@see rating}.
      * @returns {Promise.<pageRatingModel>} - A Promise that, when resolved, yields a {@link pageRatingModel} containing the new rating information.
      */
-    rate(rating = '', oldRating = '') {
-        rating = rating.toString();
-        oldRating = oldRating.toString();
-        if(rating !== '1' && rating !== '0' && rating !== '') {
+    rate(rating = null, oldRating = null) {
+        if(rating !== 1 && rating !== 0 && rating !== null) {
             throw new Error('Invalid rating supplied');
         }
-        if(oldRating !== '1' && oldRating !== '0' && oldRating !== '') {
+        if(oldRating !== 1 && oldRating !== 0 && oldRating !== null) {
             throw new Error('Invalid rating supplied for the old rating');
         }
-        let pageRatingModelParser = modelParser.createParser(pageRatingModel);
-        return this._plug.at('ratings').withParams({ score: rating, previousScore: oldRating }).post(null, utility.textRequestType).then((r) => r.json()).then(pageRatingModelParser);
+        if(rating === null) {
+            rating = '';
+        }
+        if(oldRating === null) {
+            oldRating = '';
+        }
+        return this._plug.at('ratings').withParams({ score: rating, previousScore: oldRating }).post(null, utility.textRequestType).then((r) => r.json()).then(modelParser.createParser(pageRatingModel));
     }
 
     /**


### PR DESCRIPTION
Reviewed by: @killsunday 

Change page rating to take numbers (1 or 0) to set the rating, and `null` to clear it.
If a field marked as `Number` is an empty string, return `null` instead of 0