### PR TITLE
Add new functions to File and Page

### DIFF
--- a/__mocks__/customPlug.js
+++ b/__mocks__/customPlug.js
@@ -1,0 +1,8 @@
+/* eslint-env node */
+const Plug = require.requireActual('./plug.js').Plug;
+module.exports = (customFields) => {
+    Object.keys(customFields).forEach((field) => {
+        Plug.prototype[field] = customFields[field];
+    });
+    return { Plug };
+};

--- a/__tests__/custom.test.js
+++ b/__tests__/custom.test.js
@@ -36,53 +36,21 @@ describe('Special page Tests', () => {
         return cm.getDefinitions();
     });
     it('can fetch a virtual page', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withParam() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                get() {
-                    return Promise.reject({
-                        message: 'Not found',
-                        status: 404,
-                        responseText: '{"@virtual":"true"}'
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            get() {
+                return Promise.reject({ message: 'Not found', status: 404, responseText: '{"@virtual":"true"}' });
             }
-            return { Plug };
-        });
+        }));
         const Page = require('../page.js').Page;
         let p = new Page(123);
         return p.getFullInfo().then((r) => expect(r.virtual).toBe(true));
     });
     it('can get through virtual page checking when there is another failure', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withParam() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                get() {
-                    return Promise.reject({
-                        message: 'Not found',
-                        status: 404,
-                        responseText: '{"notavirtualpage":true}'
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            get() {
+                return Promise.reject({ message: 'Not found', status: 404, responseText: '{"notavirtualpage":true}' });
             }
-            return { Plug };
-        });
+        }));
         const Page = require('../page.js').Page;
         const page = new Page(123);
         const success = jest.fn();
@@ -94,27 +62,11 @@ describe('Special page Tests', () => {
         });
     });
     it('can get through virtual page checking when there is another failure (no responseText)', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withParam() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                get() {
-                    return Promise.reject({
-                        message: 'Not found',
-                        status: 404,
-                        responseText: ''
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            get() {
+                return Promise.reject({ message: 'Not found', status: 404, responseText: '' });
             }
-            return { Plug };
-        });
+        }));
         const Page = require('../page.js').Page;
         const page = new Page(123);
         const success = jest.fn();
@@ -126,27 +78,11 @@ describe('Special page Tests', () => {
         });
     });
     it('can import an archive with a conflict (no progress)', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withHeader() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                put() {
-                    return Promise.reject({
-                        message: 'Conflict',
-                        status: 409,
-                        responseText: '{}'
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            put() {
+                return Promise.reject({ message: 'Conflict', status: 409, responseText: '{}' });
             }
-            return { Plug };
-        });
+        }));
         const Page = require('../page.js').Page;
         const page = new Page(123);
         const success = jest.fn();
@@ -192,24 +128,11 @@ describe('Special page Tests', () => {
         });
     });
     it('can handle a rejection properly for Page.prototype.copy', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                post() {
-                    return Promise.reject({
-                        message: 'Conflict',
-                        status: 409,
-                        responseText: '{}'
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            post() {
+                return Promise.reject({ message: 'Conflict', status: 409, responseText: '{}' });
             }
-            return { Plug };
-        });
+        }));
         const Page = require('../page.js').Page;
         const page = new Page(123);
         const success = jest.fn();
@@ -222,24 +145,11 @@ describe('Special page Tests', () => {
         });
     });
     it('can handle a rejection properly for Page.prototype.move', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                post() {
-                    return Promise.reject({
-                        message: 'Conflict',
-                        status: 409,
-                        responseText: '{}'
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            post() {
+                return Promise.reject({ message: 'Conflict', status: 409, responseText: '{}' });
             }
-            return { Plug };
-        });
+        }));
         const Page = require('../page.js').Page;
         const page = new Page(123);
         const success = jest.fn();
@@ -252,24 +162,11 @@ describe('Special page Tests', () => {
         });
     });
     it('can handle a rejection properly for File.prototype.move', () => {
-        jest.mock('mindtouch-http.js/plug.js', () => {
-            class Plug {
-                at() {
-                    return new Plug();
-                }
-                withParams() {
-                    return new Plug();
-                }
-                post() {
-                    return Promise.reject({
-                        message: 'Conflict',
-                        status: 409,
-                        responseText: '{}'
-                    });
-                }
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            post() {
+                return Promise.reject({ message: 'Conflict', status: 409, responseText: '{}' });
             }
-            return { Plug };
-        });
+        }));
         const File = require('../file.js').File;
         const file = new File(123);
         const success = jest.fn();

--- a/__tests__/custom.test.js
+++ b/__tests__/custom.test.js
@@ -8,9 +8,7 @@ jest.unmock('../page.js');
 jest.unmock('../pageBase.js');
 jest.unmock('../lib/modelParser.js');
 jest.unmock('../contextId.js');
-
-// import { Page } from '../page.js';
-// import { ContextIdManager } from '../contextId.js';
+jest.unmock('../file.js');
 
 describe('Special page Tests', () => {
     beforeEach(() => {
@@ -186,6 +184,96 @@ describe('Special page Tests', () => {
         const page = new Page(123);
         const success = jest.fn();
         return page.importArchive({}, { name: 'test.mtarc', size: 1000, progress: () => {} }, { foo: 'bar' }).then(() => {
+            success();
+            throw new Error();
+        }).catch((e) => {
+            expect(success).not.toHaveBeenCalled();
+            expect(e).toBeDefined();
+        });
+    });
+    it('can handle a rejection properly for Page.prototype.copy', () => {
+        jest.mock('mindtouch-http.js/plug.js', () => {
+            class Plug {
+                at() {
+                    return new Plug();
+                }
+                withParams() {
+                    return new Plug();
+                }
+                post() {
+                    return Promise.reject({
+                        message: 'Conflict',
+                        status: 409,
+                        responseText: '{}'
+                    });
+                }
+            }
+            return { Plug };
+        });
+        const Page = require('../page.js').Page;
+        const page = new Page(123);
+        const success = jest.fn();
+        return page.copy({ to: 'foo/bar' }).then(() => {
+            success();
+            throw new Error();
+        }).catch((e) => {
+            expect(success).not.toHaveBeenCalled();
+            expect(e).toBeDefined();
+        });
+    });
+    it('can handle a rejection properly for Page.prototype.move', () => {
+        jest.mock('mindtouch-http.js/plug.js', () => {
+            class Plug {
+                at() {
+                    return new Plug();
+                }
+                withParams() {
+                    return new Plug();
+                }
+                post() {
+                    return Promise.reject({
+                        message: 'Conflict',
+                        status: 409,
+                        responseText: '{}'
+                    });
+                }
+            }
+            return { Plug };
+        });
+        const Page = require('../page.js').Page;
+        const page = new Page(123);
+        const success = jest.fn();
+        return page.move().then(() => {
+            success();
+            throw new Error();
+        }).catch((e) => {
+            expect(success).not.toHaveBeenCalled();
+            expect(e).toBeDefined();
+        });
+    });
+    it('can handle a rejection properly for File.prototype.move', () => {
+        jest.mock('mindtouch-http.js/plug.js', () => {
+            class Plug {
+                at() {
+                    return new Plug();
+                }
+                withParams() {
+                    return new Plug();
+                }
+                post() {
+                    return Promise.reject({
+                        message: 'Conflict',
+                        status: 409,
+                        responseText: '{}'
+                    });
+                }
+            }
+            return { Plug };
+        });
+        const File = require('../file.js').File;
+        const file = new File(123);
+        const success = jest.fn();
+        return file.move({ to: 'foo/bar', name: 'image.png' }).then(() => {
             success();
             throw new Error();
         }).catch((e) => {

--- a/__tests__/file.test.js
+++ b/__tests__/file.test.js
@@ -65,5 +65,26 @@ describe('File API', () => {
         it('can add a file revision with progress (no added info)', () => {
             return file.addRevision({}, { name: 'test.png', type: 'image/png', size: 1000, progress: () => {} });
         });
+        it('can move a file', () => {
+            return file.move({ to: 'foo/bar', name: 'image.jpg' });
+        });
+        it('can fail if no `to` parameter is sent to move()', () => {
+            const success = jest.fn();
+            return file.move().then(() => {
+                success();
+                throw new Error('The promise was resolved.');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail if no `name` parameter is sent to move()', () => {
+            const success = jest.fn();
+            return file.move({ to: 'foo/bar' }).then(() => {
+                success();
+                throw new Error('The promise was resolved.');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
     });
 });

--- a/__tests__/page.test.js
+++ b/__tests__/page.test.js
@@ -204,11 +204,8 @@ describe('Page', () => {
         it('can copy a page', () => {
             return page.copy({ to: 'foo/bar' });
         });
-        it('can copy a page with `deleteRedirects` specified', () => {
-            return page.copy({ to: 'foo/bar', deleteRedirects: true });
-        });
-        it('can copy a page with `deleteRedirects` explicitly false', () => {
-            return page.copy({ to: 'foo/bar', deleteRedirects: false });
+        it('can copy a page with `allow` specified', () => {
+            return page.copy({ to: 'foo/bar', allow: 'deleteredirects' });
         });
         it('can fail if the `to` parameter is not sent to copy()', () => {
             const success = jest.fn();
@@ -222,6 +219,15 @@ describe('Page', () => {
         it('can fail if the `abort` parameter is set to an invalid value', () => {
             const success = jest.fn();
             return page.copy({ to: 'foo/bar', abort: 'invalid' }).then(() => {
+                success();
+                throw new Error('The promise was resolved.');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail if the `allow` parameter is set to an invalid value', () => {
+            const success = jest.fn();
+            return page.copy({ to: 'foo/bar', allow: 'invalid' }).then(() => {
                 success();
                 throw new Error('The promise was resolved.');
             }).catch(() => {

--- a/__tests__/page.test.js
+++ b/__tests__/page.test.js
@@ -201,6 +201,33 @@ describe('Page', () => {
         it('can import an archive with progress (no params)', () => {
             return page.importArchive({}, { name: 'test.mtarc', size: 1000, progress: () => {} });
         });
+        it('can copy a page', () => {
+            return page.copy({ to: 'foo/bar' });
+        });
+        it('can copy a page with `deleteRedirects` specified', () => {
+            return page.copy({ to: 'foo/bar', deleteRedirects: true });
+        });
+        it('can copy a page with `deleteRedirects` explicitly false', () => {
+            return page.copy({ to: 'foo/bar', deleteRedirects: false });
+        });
+        it('can fail if the `to` parameter is not sent to copy()', () => {
+            const success = jest.fn();
+            return page.copy().then(() => {
+                success();
+                throw new Error('The promise was resolved.');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail if the `abort` parameter is set to an invalid value', () => {
+            const success = jest.fn();
+            return page.copy({ to: 'foo/bar', abort: 'invalid' }).then(() => {
+                success();
+                throw new Error('The promise was resolved.');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
     });
     describe('Page manager', () => {
         describe('functional tests', () => {

--- a/lib/__tests__/modelParser.test.js
+++ b/lib/__tests__/modelParser.test.js
@@ -32,6 +32,10 @@ describe('Model Parser', () => {
         it('returns false (default)', () => {
             expect(modelParser.to.boolean()).toBe(false);
         });
+        it('works if the boolean has already been parsed', () => {
+            expect(modelParser.to.boolean(true)).toBe(true);
+            expect(modelParser.to.boolean(false)).toBe(false);
+        });
         it('returns a valid date', () => {
             let toDate = modelParser.to.date('Mon, 05 Oct 2015 18:44:27 GMT');
             expect(toDate).toBeDefined();
@@ -50,6 +54,9 @@ describe('Model Parser', () => {
             expect(toInteger).toBe(5);
             let toFloat = modelParser.to.number('3.6');
             expect(toFloat).toBe(3.6);
+        });
+        it('works if the number has already been parsed', () => {
+            expect(modelParser.to.number(400)).toBe(400);
         });
         it('thows converting to integer', () => {
             let err;

--- a/lib/__tests__/utility.test.js
+++ b/lib/__tests__/utility.test.js
@@ -49,6 +49,6 @@ describe('Martian utility', () => {
         expect(utility.escapeHTML('<script type="text/javascript">alert("FOO");</script>'))
             .toBe('&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;FOO&quot;);&lt;/script&gt;');
         expect(utility.escapeHTML('¢£¥€©®<>"&\''))
-            .toBe('&cent;&pound;&yen;&euro;&copy;&reg;&lt;&gt;&quot;&amp;&#39;');
+            .toBe('¢£¥€©®&lt;&gt;&quot;&amp;&#39;');
     });
 });

--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -23,7 +23,7 @@ import { dispatchEvent } from './dispatchEvent.js';
 export const modelParser = {
     to: {
         boolean(value) {
-            return value === 'true';
+            return value === true || value === 'true';
         },
         date(value) {
             const dateValue = new Date(value);
@@ -33,11 +33,14 @@ export const modelParser = {
             return dateValue;
         },
         number(value) {
+            if(typeof value === 'number') {
+                return value;
+            }
             if(value === '') {
                 return null;
             }
             const intValue = Number(value);
-            if(isNaN(intValue) || (value !== '' && String(intValue) !== value)) {
+            if(String(intValue) !== value) {
                 throw new Error('Failed converting to integer');
             }
             return intValue;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -19,12 +19,13 @@
 import 'core-js/modules/es6.string.includes';
 
 const _htmlEscapeChars = {
-    '¢': 'cent',
-    '£': 'pound',
-    '¥': 'yen',
-    '€': 'euro',
-    '©': 'copy',
-    '®': 'reg',
+
+    // '¢': 'cent',
+    // '£': 'pound',
+    // '¥': 'yen',
+    // '€': 'euro',
+    // '©': 'copy',
+    // '®': 'reg', Removed due to Dream unable to encode properly
     '<': 'lt',
     '>': 'gt',
     '"': 'quot',

--- a/models/__tests__/models.test.js
+++ b/models/__tests__/models.test.js
@@ -20,89 +20,23 @@
 jest.unmock('../../lib/modelParser.js');
 import { Mocks } from './mock/mocks.js';
 import { modelParser } from '../../lib/modelParser.js';
-import { contextIdModel } from '../contextId.model.js';
-import { contextIdsModel } from '../contextIds.model.js';
-import { contextMapModel } from '../contextMap.model.js';
-import { contextMapsModel } from '../contextMaps.model.js';
-import { fileModel } from '../file.model.js';
-import { fileRevisionsModel } from '../fileRevisions.model.js';
-import { groupModel } from '../group.model.js';
-import { groupListModel } from '../groupList.model.js';
-import { learningPathModel } from '../learningPath.model.js';
-import { learningPathsModel } from '../learningPaths.model.js';
-import { pageModel } from '../page.model.js';
-import { pageContentsModel } from '../pageContents.model.js';
-import { pageTreeModel } from '../pageTree.model.js';
-import { pageEditModel } from '../pageEdit.model.js';
-import { pageFilesModel } from '../pageFiles.model.js';
-import { pageMoveModel } from '../pageMove.model.js';
-import { pagePropertyModel } from '../pageProperty.model.js';
-import { pagePropertiesModel } from '../pageProperties.model.js';
-import { pageRatingModel } from '../pageRating.model.js';
-import { pageRatingsModel } from '../pageRatings.model.js';
-import { pageTagsModel } from '../pageTags.model.js';
-import { searchModel } from '../search.model.js';
-import { subpagesModel } from '../subpages.model.js';
-import { userModel } from '../user.model.js';
-import { userListModel } from '../userList.model.js';
-import { userActivityModel } from '../userActivity.model.js';
-import { eventModel } from '../event.model.js';
-import { userHistoryDetailModel } from '../userHistoryDetail.model.js';
-import { userHistoryModel } from '../userHistory.model.js';
-import { pageHistoryModel } from '../pageHistory.model.js';
-import { pageHistoryDetailModel } from '../pageHistoryDetail.model.js';
-import { relatedPagesModel } from '../relatedPages.model.js';
-import { siteTagsModelGet, siteTagsModelPost } from '../siteTags.model.js';
-import { reportLogsModel } from '../reportLogs.model.js';
-import { logUrlModel } from '../logUrl.model.js';
-import { workflowsModel } from '../workflows.model.js';
 
-// Add all imported models here for property checking
-const allModels = [
-    contextIdModel,
-    contextIdsModel,
-    contextMapModel,
-    contextMapsModel,
-    fileModel,
-    fileRevisionsModel,
-    groupModel,
-    groupListModel,
-    learningPathModel,
-    learningPathsModel,
-    pageModel,
-    pageContentsModel,
-    pageTreeModel,
-    pageEditModel,
-    pageFilesModel,
-    pageMoveModel,
-    pagePropertyModel,
-    pagePropertiesModel,
-    pageRatingModel,
-    pageRatingsModel,
-    pageTagsModel,
-    searchModel,
-    subpagesModel,
-    userModel,
-    userListModel,
-    userActivityModel,
-    eventModel,
-    userHistoryDetailModel,
-    userHistoryModel,
-    pageHistoryModel,
-    pageHistoryDetailModel,
-    relatedPagesModel,
-    siteTagsModelGet,
-    siteTagsModelPost,
-    reportLogsModel,
-    logUrlModel,
-    workflowsModel
-];
+const fs = require('fs');
+const files = fs.readdirSync('./models');
+let modelMap = {};
+files.forEach((file) => {
+    if(file.endsWith('.model.js')) {
+        const module = require.requireActual(`../${file}`);
+        modelMap = Object.assign(modelMap, module);
+    }
+});
 
 describe('Models', () => {
     describe('Property checking', () => {
         it('only has valid properties', () => {
             const defaultProps = [ 'field', 'name', 'isArray', 'transform', 'constructTransform' ];
             const preProcessorProps = [ 'preProcessor', 'model' ];
+            const allModels = Object.values(modelMap);
             function propsAreValid(obj, validProps) {
                 return Object.keys(obj).every((prop) => validProps.includes(prop));
             }
@@ -117,6 +51,7 @@ describe('Models', () => {
                     entry.transform.forEach((subEntry) => testEntry(subEntry, validProps));
                 }
             }
+
             allModels.forEach((model) => {
                 if(!Array.isArray(model)) {
                     testEntry(model, preProcessorProps);
@@ -128,214 +63,214 @@ describe('Models', () => {
     });
     describe('Available logs model', () => {
         it('can parse a list of logs', () => {
-            expect(modelParser.createParser(contextIdModel)(Mocks.contextIdDefinition)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextIdModel)(Mocks.contextIdDefinition)).toBeDefined();
         });
     });
     describe('Log URL model', () => {
         it('can parse a log URL', () => {
-            expect(modelParser.createParser(contextIdModel)(Mocks.contextIdDefinition)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextIdModel)(Mocks.contextIdDefinition)).toBeDefined();
         });
     });
     describe('Context ID models', () => {
         it('can parse a context ID', () => {
-            expect(modelParser.createParser(contextIdModel)(Mocks.contextIdDefinition)).toBeDefined();
-            expect(modelParser.createParser(contextIdModel)(Mocks.contextIdDefinitionsSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextIdModel)(Mocks.contextIdDefinition)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextIdModel)(Mocks.contextIdDefinitionsSingle)).toBeDefined();
         });
         it('can parse a list of context IDs', () => {
-            expect(modelParser.createParser(contextIdsModel)(Mocks.contextIdDefinitions)).toBeDefined();
-            expect(modelParser.createParser(contextIdsModel)(Mocks.contextIdDefinitionsSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextIdsModel)(Mocks.contextIdDefinitions)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextIdsModel)(Mocks.contextIdDefinitionsSingle)).toBeDefined();
         });
         it('can parse a context map', () => {
-            expect(modelParser.createParser(contextMapModel)(Mocks.contextMap)).toBeDefined();
-            expect(modelParser.createParser(contextMapModel)(Mocks.contextMapVerbose)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextMapModel)(Mocks.contextMap)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextMapModel)(Mocks.contextMapVerbose)).toBeDefined();
         });
         it('can parse a list of context maps', () => {
-            expect(modelParser.createParser(contextMapsModel)(Mocks.contextMaps)).toBeDefined();
-            expect(modelParser.createParser(contextMapsModel)(Mocks.contextMapsSingleLanguage)).toBeDefined();
-            expect(modelParser.createParser(contextMapsModel)(Mocks.contextMapSingleSingle)).toBeDefined();
-            expect(modelParser.createParser(contextMapsModel)(Mocks.contextMapsEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextMapsModel)(Mocks.contextMaps)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextMapsModel)(Mocks.contextMapsSingleLanguage)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextMapsModel)(Mocks.contextMapSingleSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.contextMapsModel)(Mocks.contextMapsEmpty)).toBeDefined();
         });
     });
     describe('File model', () => {
         it('can parse file info', () => {
-            expect(modelParser.createParser(fileModel)(Mocks.file)).toBeDefined();
-            expect(modelParser.createParser(fileModel)(Mocks.fileReduced)).toBeDefined();
+            expect(modelParser.createParser(modelMap.fileModel)(Mocks.file)).toBeDefined();
+            expect(modelParser.createParser(modelMap.fileModel)(Mocks.fileReduced)).toBeDefined();
         });
         it('can parse a list of file revisions', () => {
-            expect(modelParser.createParser(fileRevisionsModel)(Mocks.fileRevisions)).toBeDefined();
-            expect(modelParser.createParser(fileRevisionsModel)(Mocks.fileRevisionsSingle)).toBeDefined();
-            expect(modelParser.createParser(fileRevisionsModel)(Mocks.fileRevisionsEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.fileRevisionsModel)(Mocks.fileRevisions)).toBeDefined();
+            expect(modelParser.createParser(modelMap.fileRevisionsModel)(Mocks.fileRevisionsSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.fileRevisionsModel)(Mocks.fileRevisionsEmpty)).toBeDefined();
         });
     });
     describe('Group model', () => {
         it('can parse group info', () => {
-            expect(modelParser.createParser(groupModel)(Mocks.group)).toBeDefined();
+            expect(modelParser.createParser(modelMap.groupModel)(Mocks.group)).toBeDefined();
         });
         it('can parse a list of groups', () => {
-            expect(modelParser.createParser(groupListModel)(Mocks.groupListing)).toBeDefined();
-            expect(modelParser.createParser(groupListModel)(Mocks.groupListingSingle)).toBeDefined();
-            expect(modelParser.createParser(groupListModel)(Mocks.groupListingEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.groupListModel)(Mocks.groupListing)).toBeDefined();
+            expect(modelParser.createParser(modelMap.groupListModel)(Mocks.groupListingSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.groupListModel)(Mocks.groupListingEmpty)).toBeDefined();
         });
     });
     describe('Learning Path model', () => {
         it('can parse learning path', () => {
-            expect(modelParser.createParser(learningPathModel)(Mocks.learningPath)).toBeDefined();
-            expect(modelParser.createParser(learningPathModel)(Mocks.learningPathSinglePage)).toBeDefined();
-            expect(modelParser.createParser(learningPathModel)(Mocks.learningPathNoPages)).toBeDefined();
+            expect(modelParser.createParser(modelMap.learningPathModel)(Mocks.learningPath)).toBeDefined();
+            expect(modelParser.createParser(modelMap.learningPathModel)(Mocks.learningPathSinglePage)).toBeDefined();
+            expect(modelParser.createParser(modelMap.learningPathModel)(Mocks.learningPathNoPages)).toBeDefined();
         });
         it('can parse multiple learning paths', () => {
-            expect(modelParser.createParser(learningPathsModel)(Mocks.learningPaths)).toBeDefined();
-            expect(modelParser.createParser(learningPathsModel)(Mocks.learningPathsSingular)).toBeDefined();
+            expect(modelParser.createParser(modelMap.learningPathsModel)(Mocks.learningPaths)).toBeDefined();
+            expect(modelParser.createParser(modelMap.learningPathsModel)(Mocks.learningPathsSingular)).toBeDefined();
         });
     });
     describe('Page model', () => {
         it('can parse page info', () => {
-            expect(modelParser.createParser(pageModel)(Mocks.page)).toBeDefined();
-            expect(modelParser.createParser(pageModel)(Mocks.pageInfo)).toBeDefined();
-            expect(modelParser.createParser(pageModel)(Mocks.virtualPage)).toBeDefined();
-            expect(modelParser.createParser(pageModel)(Mocks.draft)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageModel)(Mocks.page)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageModel)(Mocks.pageInfo)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageModel)(Mocks.virtualPage)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageModel)(Mocks.draft)).toBeDefined();
         });
     });
     describe('Page contents model', () => {
         it('can parse page contents info', () => {
-            expect(modelParser.createParser(pageContentsModel)(Mocks.pageContent)).toBeDefined();
-            expect(modelParser.createParser(pageContentsModel)(Mocks.pageContentSimple)).toBeDefined();
-            expect(modelParser.createParser(pageContentsModel)(Mocks.draftContent)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageContentsModel)(Mocks.pageContent)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageContentsModel)(Mocks.pageContentSimple)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageContentsModel)(Mocks.draftContent)).toBeDefined();
         });
     });
     describe('Page tree model', () => {
         it('can parse page tree info', () => {
-            expect(modelParser.createParser(pageTreeModel)(Mocks.pageTree)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageTreeModel)(Mocks.pageTree)).toBeDefined();
         });
     });
     describe('Page edit model', () => {
         it('can parse a page edit info', () => {
-            expect(modelParser.createParser(pageEditModel)(Mocks.pageSetContents)).toBeDefined();
-            expect(modelParser.createParser(pageEditModel)(Mocks.pageSetContentsConflict)).toBeDefined();
-            expect(modelParser.createParser(pageEditModel)(Mocks.draftSetContents)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageEditModel)(Mocks.pageSetContents)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageEditModel)(Mocks.pageSetContentsConflict)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageEditModel)(Mocks.draftSetContents)).toBeDefined();
         });
     });
     describe('Page files model', () => {
         it('can parse page files info', () => {
-            expect(modelParser.createParser(pageFilesModel)(Mocks.fileRevisions)).toBeDefined();
-            expect(modelParser.createParser(pageFilesModel)(Mocks.fileRevisionsSingle)).toBeDefined();
-            expect(modelParser.createParser(pageFilesModel)(Mocks.fileRevisionsEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageFilesModel)(Mocks.fileRevisions)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageFilesModel)(Mocks.fileRevisionsSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageFilesModel)(Mocks.fileRevisionsEmpty)).toBeDefined();
         });
     });
     describe('Page move model', () => {
         it('can parse page move info', () => {
-            expect(modelParser.createParser(pageMoveModel)(Mocks.pageMove)).toBeDefined();
-            expect(modelParser.createParser(pageMoveModel)(Mocks.pageMoveSingle)).toBeDefined();
-            expect(modelParser.createParser(pageMoveModel)(Mocks.pageMoveEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageMoveModel)(Mocks.pageMove)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageMoveModel)(Mocks.pageMoveSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageMoveModel)(Mocks.pageMoveEmpty)).toBeDefined();
         });
     });
     describe('Page properties model', () => {
         it('can parse page proerty info', () => {
-            expect(modelParser.createParser(pagePropertyModel)(Mocks.pageProperty)).toBeDefined();
-            expect(modelParser.createParser(pagePropertyModel)(Mocks.pagePropertyPage)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pagePropertyModel)(Mocks.pageProperty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pagePropertyModel)(Mocks.pagePropertyPage)).toBeDefined();
         });
         it('can parse a list of page properties', () => {
-            expect(modelParser.createParser(pagePropertiesModel)(Mocks.pageProperties)).toBeDefined();
-            expect(modelParser.createParser(pagePropertiesModel)(Mocks.pagePropertiesSingle)).toBeDefined();
-            expect(modelParser.createParser(pagePropertiesModel)(Mocks.pagePropertiesEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pagePropertiesModel)(Mocks.pageProperties)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pagePropertiesModel)(Mocks.pagePropertiesSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pagePropertiesModel)(Mocks.pagePropertiesEmpty)).toBeDefined();
         });
     });
     describe('Page ratings model', () => {
         it('can parse page rating info', () => {
-            expect(modelParser.createParser(pageRatingModel)(Mocks.pageRating)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageRatingModel)(Mocks.pageRating)).toBeDefined();
         });
         it('can parse a list of page ratings', () => {
-            expect(modelParser.createParser(pageRatingsModel)(Mocks.pageRatings)).toBeDefined();
-            expect(modelParser.createParser(pageRatingsModel)(Mocks.pageRatingsSingle)).toBeDefined();
-            expect(modelParser.createParser(pageRatingsModel)(Mocks.pageRatingsEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageRatingsModel)(Mocks.pageRatings)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageRatingsModel)(Mocks.pageRatingsSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageRatingsModel)(Mocks.pageRatingsEmpty)).toBeDefined();
         });
     });
     describe('Page tags model', () => {
         it('can parse page tags info', () => {
-            expect(modelParser.createParser(pageTagsModel)(Mocks.pageTags)).toBeDefined();
-            expect(modelParser.createParser(pageTagsModel)(Mocks.pageTagsSingle)).toBeDefined();
-            expect(modelParser.createParser(pageTagsModel)(Mocks.pageTagsEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageTagsModel)(Mocks.pageTags)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageTagsModel)(Mocks.pageTagsSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageTagsModel)(Mocks.pageTagsEmpty)).toBeDefined();
         });
     });
     describe('Page history model', () => {
         it('can parse a list of page history event summary', () => {
-            expect(modelParser.createParser(pageHistoryModel)(Mocks.pageEventSummary)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageHistoryModel)(Mocks.pageEventSummary)).toBeDefined();
         });
         it('can parse a single page history event summary', () => {
-            expect(modelParser.createParser(pageHistoryModel)(Mocks.pageEventSummarySingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageHistoryModel)(Mocks.pageEventSummarySingle)).toBeDefined();
         });
     });
     describe('Page history detail model', () => {
         it('can parse a single page history event detail', () => {
-            expect(modelParser.createParser(pageHistoryDetailModel)(Mocks.eventDetail)).toBeDefined();
+            expect(modelParser.createParser(modelMap.pageHistoryDetailModel)(Mocks.eventDetail)).toBeDefined();
         });
     });
     describe('Search model', () => {
         it('can parse search result info', () => {
-            expect(modelParser.createParser(searchModel)(Mocks.search)).toBeDefined();
-            expect(modelParser.createParser(searchModel)(Mocks.searchSingle)).toBeDefined();
-            expect(modelParser.createParser(searchModel)(Mocks.searchEmpty)).toBeDefined();
-            expect(modelParser.createParser(searchModel)(Mocks.searchSingleNoResultSummary)).toBeDefined();
+            expect(modelParser.createParser(modelMap.searchModel)(Mocks.search)).toBeDefined();
+            expect(modelParser.createParser(modelMap.searchModel)(Mocks.searchSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.searchModel)(Mocks.searchEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.searchModel)(Mocks.searchSingleNoResultSummary)).toBeDefined();
         });
     });
     describe('Subpages model', () => {
         it('can parse subpages info', () => {
-            expect(modelParser.createParser(subpagesModel)(Mocks.subpages)).toBeDefined();
-            expect(modelParser.createParser(subpagesModel)(Mocks.subpagesSingle)).toBeDefined();
-            expect(modelParser.createParser(subpagesModel)(Mocks.subpagesEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.subpagesModel)(Mocks.subpages)).toBeDefined();
+            expect(modelParser.createParser(modelMap.subpagesModel)(Mocks.subpagesSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.subpagesModel)(Mocks.subpagesEmpty)).toBeDefined();
         });
     });
     describe('Users model', () => {
         it('can parse user info', () => {
-            expect(modelParser.createParser(userModel)(Mocks.user)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userModel)(Mocks.user)).toBeDefined();
         });
         it('can parse a list of users', () => {
-            expect(modelParser.createParser(userListModel)(Mocks.users)).toBeDefined();
-            expect(modelParser.createParser(userListModel)(Mocks.usersSingle)).toBeDefined();
-            expect(modelParser.createParser(userListModel)(Mocks.userSearch)).toBeDefined();
-            expect(modelParser.createParser(userListModel)(Mocks.userSearchSingle)).toBeDefined();
-            expect(modelParser.createParser(userListModel)(Mocks.userSearchEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userListModel)(Mocks.users)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userListModel)(Mocks.usersSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userListModel)(Mocks.userSearch)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userListModel)(Mocks.userSearchSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userListModel)(Mocks.userSearchEmpty)).toBeDefined();
         });
     });
     describe('User activity model', () => {
         it('can parse a list of user activity events', () => {
-            expect(modelParser.createParser(userActivityModel)(Mocks.userActivity)).toBeDefined();
-            expect(modelParser.createParser(userActivityModel)(Mocks.userActivitySingle)).toBeDefined();
-            expect(modelParser.createParser(userActivityModel)(Mocks.userActivityEmpty)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userActivityModel)(Mocks.userActivity)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userActivityModel)(Mocks.userActivitySingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userActivityModel)(Mocks.userActivityEmpty)).toBeDefined();
         });
     });
     describe('Event model', () => {
         it('can parse an event', () => {
-            expect(modelParser.createParser(eventModel)(Mocks.event)).toBeDefined();
-            expect(modelParser.createParser(eventModel)(Mocks.eventUserName)).toBeDefined();
+            expect(modelParser.createParser(modelMap.eventModel)(Mocks.event)).toBeDefined();
+            expect(modelParser.createParser(modelMap.eventModel)(Mocks.eventUserName)).toBeDefined();
         });
     });
     describe('Event detail model', () => {
         it('can parse an event detail', () => {
-            expect(modelParser.createParser(userHistoryDetailModel)(Mocks.eventDetail)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userHistoryDetailModel)(Mocks.eventDetail)).toBeDefined();
         });
     });
     describe('Event list model', () => {
         it('can parse an event list', () => {
-            expect(modelParser.createParser(userHistoryModel)(Mocks.eventList)).toBeDefined();
+            expect(modelParser.createParser(modelMap.userHistoryModel)(Mocks.eventList)).toBeDefined();
         });
     });
     describe('Related pages model', () => {
         it('can parse a list of related pages', () => {
-            expect(modelParser.createParser(relatedPagesModel)(Mocks.relatedPages)).toBeDefined();
-            expect(modelParser.createParser(relatedPagesModel)(Mocks.relatedPagesSingle)).toBeDefined();
+            expect(modelParser.createParser(modelMap.relatedPagesModel)(Mocks.relatedPages)).toBeDefined();
+            expect(modelParser.createParser(modelMap.relatedPagesModel)(Mocks.relatedPagesSingle)).toBeDefined();
         });
     });
     describe('Site Tags model', () => {
         it('can parse a list of site tags', () => {
-            expect(modelParser.createParser(siteTagsModelGet)(Mocks.siteTagsGet)).toBeDefined();
-            expect(modelParser.createParser(siteTagsModelPost)(Mocks.siteTagsPost)).toBeDefined();
-            expect(modelParser.createParser(siteTagsModelPost)('')).toBeDefined();
+            expect(modelParser.createParser(modelMap.siteTagsModelGet)(Mocks.siteTagsGet)).toBeDefined();
+            expect(modelParser.createParser(modelMap.siteTagsModelPost)(Mocks.siteTagsPost)).toBeDefined();
+            expect(modelParser.createParser(modelMap.siteTagsModelPost)('')).toBeDefined();
         });
     });
     describe('Workflows model', () => {
         it('can parse a workflow response', () => {
-            expect(modelParser.createParser(workflowsModel)(Mocks.workflows)).toBeDefined();
+            expect(modelParser.createParser(modelMap.workflowsModel)(Mocks.workflows)).toBeDefined();
         });
     });
 });

--- a/models/apiError.model.js
+++ b/models/apiError.model.js
@@ -36,7 +36,8 @@ export const apiErrorModel = {
                 { field: [ 'arguments', 'argument' ], name: 'arguments', isArray: true },
                 { field: 'exception' },
                 { field: 'message' },
-                { field: 'resource' }
+                { field: 'resource' },
+                { field: 'data' }
             ]
         },
         { field: 'errorText' }

--- a/models/apiError.model.js
+++ b/models/apiError.model.js
@@ -1,0 +1,44 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const apiErrorModel = {
+    preProcessor(data) {
+        try {
+            data.errorInfo = JSON.parse(data.responseText);
+        } catch(e) {
+            data.errorText = data.responseText;
+        }
+        delete data.responseText;
+        return data;
+    },
+    model: [
+        { field: 'status' },
+        { field: 'message' },
+        {
+            field: 'errorInfo',
+            name: 'info',
+            transform: [
+                { field: [ 'arguments', 'argument' ], name: 'arguments', isArray: true },
+                { field: 'exception' },
+                { field: 'message' },
+                { field: 'resource' }
+            ]
+        },
+        { field: 'errorText' }
+    ]
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindtouch-martian",
-  "version": "1.10.2",
+  "version": "1.11.1",
   "description": "Core JavaScript API for MindTouch",
   "license": "Apache-2.0",
   "main": false,

--- a/page.js
+++ b/page.js
@@ -139,7 +139,7 @@ export class Page extends PageBase {
      * @param {Boolean} [params.attachments=true] - Copy the attachments of the page on copy.
      * @param {Boolean} [params.recursive=false] - Copy the child hierarchy of the original page.
      * @param {String} [params.abort='exists'] - Specifies condition under which to prevent the update. Allowed values are 'exists' and 'never'.
-     * @param {Boolean} [params.deleteRedirects=false] - Specifies whether or not to perform the copy if a redirect would be deleted as a result.
+     * @param {String} [params.allow] - Specifies condition under which to allow the update when an error would normally be thrown.
      * @returns {Promise.<pageMoveModel>} - A Promise that, when resolved, yields a {@link pageMoveModel} containing information regarding the move operation.
      */
     copy(params = {}) {
@@ -149,11 +149,8 @@ export class Page extends PageBase {
         if(params.abort && params.abort !== 'exists' && params.abort !== 'never') {
             return Promise.reject(new Error('The `abort` parameter must be either "exists" or "never".'));
         }
-        if('deleteRedirects' in params) {
-            if(params.deleteRedirects === true) {
-                params.allow = 'deleteredirects';
-            }
-            delete params.deleteRedirects;
+        if(params.allow && params.allow !== 'deleteredirects') {
+            return Promise.reject('The `allow` parameter, if specified, must have a value of "deleteredirects"');
         }
         return this._plug.at('copy')
             .withParams(params)
@@ -171,7 +168,7 @@ export class Page extends PageBase {
     move(params = {}) {
         return this._plug.at('move')
             .withParams(params)
-            .post(null, 'text/plain; charset=utf-8')
+            .post(null, utility.textRequestType)
             .then((r) => r.json())
             .then(modelParser.createParser(pageMoveModel))
             .catch((err) => Promise.reject(this._errorParser(err)));

--- a/page.js
+++ b/page.js
@@ -13,6 +13,7 @@ import { pageMoveModel } from './models/pageMove.model.js';
 import { pageRatingsModel } from './models/pageRatings.model.js';
 import { pageDeleteModel } from './models/pageDelete.model.js';
 import { importArchiveModel } from './models/importArchive.model.js';
+import { apiErrorModel } from './models/apiError.model.js';
 
 /**
  * A class for managing a published page.
@@ -28,6 +29,7 @@ export class Page extends PageBase {
         super(id);
         this._settings = settings;
         this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'pages', this._id);
+        this._errorParser = modelParser.createParser(apiErrorModel);
     }
 
     /**
@@ -129,13 +131,50 @@ export class Page extends PageBase {
     }
 
     /**
+     * Copy a page to a specified location
+     * @param {Object} params - The params that direct the copy operation.
+     * @param {String} params.to - The new page location including the path and name of the page.
+     * @param {String} [params.title] - Set the title of the page. If not specified, default to the original title.
+     * @param {Boolean} [params.tags=true] - Copy the tags of the page on copy.
+     * @param {Boolean} [params.attachments=true] - Copy the attachments of the page on copy.
+     * @param {Boolean} [params.recursive=false] - Copy the child hierarchy of the original page.
+     * @param {String} [params.abort='exists'] - Specifies condition under which to prevent the update. Allowed values are 'exists' and 'never'.
+     * @param {Boolean} [params.deleteRedirects=false] - Specifies whether or not to perform the copy if a redirect would be deleted as a result.
+     * @returns {Promise.<pageMoveModel>} - A Promise that, when resolved, yields a {@link pageMoveModel} containing information regarding the move operation.
+     */
+    copy(params = {}) {
+        if(!params.to) {
+            return Promise.reject(new Error('The copy target location must be specified in the `to` parameter.'));
+        }
+        if(params.abort && params.abort !== 'exists' && params.abort !== 'never') {
+            return Promise.reject(new Error('The `abort` parameter must be either "exists" or "never".'));
+        }
+        if('deleteRedirects' in params) {
+            if(params.deleteRedirects === true) {
+                params.allow = 'deleteredirects';
+            }
+            delete params.deleteRedirects;
+        }
+        return this._plug.at('copy')
+            .withParams(params)
+            .post(null, utility.textRequestType)
+            .then((r) => r.json())
+            .then(modelParser.createParser(pageMoveModel))
+            .catch((err) => Promise.reject(this._errorParser(err)));
+    }
+
+    /**
      * Move a page to a new location in the hierarchy.
      * @param {Object} [params] - Additional parameters to direct the API request.
      * @returns {Promise.<pageMoveModel>} - A Promise that, when resolved, yields a {@link pageMoveModel} containing information regarding the move operation.
      */
     move(params = {}) {
-        let pageMoveModelParser = modelParser.createParser(pageMoveModel);
-        return this._plug.at('move').withParams(params).post(null, 'text/plain; charset=utf-8').then((r) => r.json()).then(pageMoveModelParser);
+        return this._plug.at('move')
+            .withParams(params)
+            .post(null, 'text/plain; charset=utf-8')
+            .then((r) => r.json())
+            .then(modelParser.createParser(pageMoveModel))
+            .catch((err) => Promise.reject(this._errorParser(err)));
     }
 
     /**


### PR DESCRIPTION
* Add File.prototype.move
* Add Page.prototype.copy
* Add apiError.model.js for the common API exception format.
* Update tests for the above
* Refactor the model parsing tests to just read all `*.model.js` files from the file system and dynamically `require` them.