### PR TITLE
optimize performance on unparsed properties

### DIFF
--- a/lib/propWatcher.js
+++ b/lib/propWatcher.js
@@ -27,10 +27,10 @@ export class PropWatcher {
         this._allPropPaths = [];
         this._accessedPropPaths = [];
         setRecursivePathGetter(obj, (propPath) => {
-            this._accessedPropPaths.push(propPath);
+            this._accessedPropPaths[propPath] = true;
         }, this._allPropPaths);
     }
     getUnaccessed() {
-        return this._allPropPaths.filter((propPath) => !this._accessedPropPaths.includes(propPath));
+        return this._allPropPaths.filter((propPath) => !this._accessedPropPaths[propPath]);
     }
 }


### PR DESCRIPTION
reviewed by: @aaronmars @JeremyRH 

- parsing unaccessed properties in models was inefficient at large volumes of data, a small optimization corrects this.