### PR TITLE
Add Licence API functionality

### DIFF
--- a/__tests__/license.test.js
+++ b/__tests__/license.test.js
@@ -1,0 +1,74 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-env jasmine, jest */
+jest.unmock('../license.js');
+import { License } from '../license.js';
+
+describe('License', () => {
+    let license = null;
+    beforeEach(() => {
+        license = new License();
+    });
+    afterEach(() => {
+        license = null;
+    });
+    it('can fetch the usage (no parameters)', () => {
+        return license.getUsage();
+    });
+    it('can fetch the usage (all parameters)', () => {
+        return license.getUsage({
+            since: new Date(2015, 12, 31, 12, 12, 0),
+            upTo: new Date(Date.now()),
+            version: 2
+        });
+    });
+    it('can fail if an invalid `since` value is sent', () => {
+        const success = jest.fn();
+        return license.getUsage({ since: '20151231121200' }).then(() => {
+            success();
+            throw new Error('Promise was resolved');
+        }).catch(() => {
+            expect(success).not.toHaveBeenCalled();
+        });
+    });
+    it('can fail if an invalid `upTo` value is sent', () => {
+        const success = jest.fn();
+        return license.getUsage({ upTo: 20151231121200 }).then(() => {
+            success();
+            throw new Error('Promise was resolved');
+        }).catch(() => {
+            expect(success).not.toHaveBeenCalled();
+        });
+    });
+    it('can fetch the usage logs', () => {
+        return license.getUsageLogs();
+    });
+    it('can fetch the URL for a usage log', () => {
+        return license.getUsageLogUrl('foo');
+    });
+    it('can fail if no name is supplied to fetch a log URL.', () => {
+        const success = jest.fn();
+        return license.getUsageLogUrl().then(() => {
+            success();
+            throw new Error('Promise was resolved.');
+        }).catch(() => {
+            expect(success).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/lib/__tests__/modelParser.test.js
+++ b/lib/__tests__/modelParser.test.js
@@ -49,6 +49,15 @@ describe('Model Parser', () => {
             }
             expect(err).toBeDefined();
         });
+        it('returns a valid API-formatted date', () => {
+            const apiDate14 = modelParser.to.apiDate('20160101120059');
+            expect(apiDate14 instanceof Date).toBe(true);
+            const apiDate8 = modelParser.to.apiDate('20160101');
+            expect(apiDate8 instanceof Date).toBe(true);
+        });
+        it('throws an error for an invalid API-formatted date', () => {
+            expect(() => modelParser.to.apiDate('201601011200')).toThrow();
+        });
         it('returns a valid integer', () => {
             let toInteger = modelParser.to.number('5');
             expect(toInteger).toBe(5);

--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -32,6 +32,20 @@ export const modelParser = {
             }
             return dateValue;
         },
+        apiDate(value) {
+            if(value.length !== 14 && value.length !== 8) {
+                throw new Error('Failed converting an API date: The raw value must be a string of length 8 or 14');
+            }
+            const parts = [
+                value.slice(0, 4),
+                value.slice(4, 6),
+                value.slice(6, 8),
+                value.slice(8, 10),
+                value.slice(10, 12),
+                value.slice(12)
+            ];
+            return new Date(...parts);
+        },
         number(value) {
             if(typeof value === 'number') {
                 return value;

--- a/license.js
+++ b/license.js
@@ -1,0 +1,61 @@
+import { Plug } from 'mindtouch-http.js/plug.js';
+import { Settings } from './lib/settings.js';
+import { utility } from './lib/utility.js';
+import { modelParser } from './lib/modelParser.js';
+import { licenseUsageModel } from './models/licenseUsage.model.js';
+import { licenseUsageLogsModel } from './models/licenseUsageLogs.model.js';
+
+export class License {
+
+    /**
+     * Construct a new License object.
+     * @param {Settings} [settings] - The {@link Settings} information to use in construction. If not supplied, the default settings are used.
+     */
+    constructor(settings = new Settings()) {
+        this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'license');
+    }
+
+    /**
+     * Retrieve license usage totals for the current license period
+     * @param {Object} [options] - Parameters that will direct the usage information that is returned.
+     * @param {Date} [options.since] - Get license usage starting at this date.
+     * @param {Date} [options.upTo=Date.now()] - Get license usage ending at this date.
+     */
+    getUsage(options = {}) {
+        const params = {};
+        if(options.since) {
+            if(!(options.since instanceof Date)) {
+                return Promise.reject(new Error('The `since` parameter must be of type Date.'));
+            }
+            params.since = utility.getApiDateString(options.since);
+        }
+        if(options.upTo) {
+            if(!(options.upTo instanceof Date)) {
+                return Promise.reject(new Error('The `upTo` parameter must be of type Date.'));
+            }
+            params.upto = utility.getApiDateString(options.upTo);
+        }
+        return this._plug.at('usage').withParams(params).get().then((r) => r.json()).then(modelParser.createParser(licenseUsageModel));
+    }
+
+    /**
+     * Retrieve license usage totals for the current license period.
+     */
+    getUsageLogs() {
+        return this._plug.at('usage', 'logs').get().then((r) => r.json()).then(modelParser.createParser(licenseUsageLogsModel));
+    }
+
+    /**
+     * Retrieve the download URL for a license usage log.
+     * @param {String} name - The name identifier for the usage log.
+     */
+    getUsageLogUrl(name) {
+        if(!name) {
+            return Promise.reject(new Error('The log name must be supplied.'));
+        }
+        return this._plug.at('usage', 'logs', name, 'url')
+            .get()
+            .then((r) => r.json())
+            .then(modelParser.createParser([ { field: 'url' } ]));
+    }
+}

--- a/models/licenseUsage.model.js
+++ b/models/licenseUsage.model.js
@@ -1,0 +1,37 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const helpRequestData = [
+    { field: '@name', name: 'name' },
+    { field: '@count', name: 'count', transform: 'number' }
+];
+export const licenseUsageModel = [
+    { field: '@count', name: 'count', transform: 'number' },
+    { field: '@date.start', name: 'startDate', transform: 'apiDate' },
+    { field: '@date.expiration', name: 'expirationDate', transform: 'apiDate' },
+    { field: '@anually-licensed-help-requests', name: 'annuallyLicensedHelpRequests' },
+    {
+        field: 'totals',
+        isArray: true,
+        transform: [
+            { field: '@date', name: 'date', transform: 'apiDate' },
+            { field: [ 'custom', 'origin' ], name: 'customRequests', isArray: true, transform: helpRequestData },
+            { field: [ 'mt-requests', 'origin' ], name: 'mtRequests', isArray: true, transform: helpRequestData }
+        ]
+    }
+];

--- a/models/licenseUsageLogs.model.js
+++ b/models/licenseUsageLogs.model.js
@@ -1,0 +1,31 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const licenseUsageLogModel = [
+    {
+        field: 'log',
+        name: 'logs',
+        isArray: true,
+        transform: [
+            { field: '@complete', name: 'complete', transform: 'boolean' },
+            { field: 'name' },
+            { field: 'modified', transform: 'date' },
+            { field: 'month' }
+        ]
+    }
+];


### PR DESCRIPTION
Reviewed by @JeremyRH 

*Add the license.js module
*Add an `apiDate` transform to model parser for date/time fields that can't be parsed directly as JS Date objects