### PR TITLE
Type-o in licenseUsageLogs.model (export should be plural)

### DIFF
--- a/models/licenseUsageLogs.model.js
+++ b/models/licenseUsageLogs.model.js
@@ -16,7 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const licenseUsageLogModel = [
+export const licenseUsageLogsModel = [
     {
         field: 'log',
         name: 'logs',


### PR DESCRIPTION
Reviewed by @JeremyRH 

The export for license usage logs should be `licenseUsageLogsModel`