### PR TITLE
Add pagePropertyBase, create draftProperty

### DIFF
--- a/__tests__/draftProperty.test.js
+++ b/__tests__/draftProperty.test.js
@@ -1,0 +1,29 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-env jasmine, jest */
+jest.unmock('../pagePropertyBase.js');
+jest.unmock('../draftProperty.js');
+import { DraftProperty } from '../draftProperty.js';
+
+describe('Draft Property', () => {
+    it('can construct a new draft property', () => {
+        const draftProp = new DraftProperty();
+        expect(draftProp).toBeDefined();
+    });
+});

--- a/__tests__/pageProperty.test.js
+++ b/__tests__/pageProperty.test.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 /* eslint-env jasmine, jest */
+jest.unmock('../pagePropertyBase.js');
 jest.unmock('../pageProperty.js');
 import { PageProperty } from '../pageProperty.js';
 
@@ -57,9 +58,13 @@ describe('Page Property', () => {
             return prop.getProperties([ 'property1', 'property2' ]);
         });
         it('can can fail gracefully if supplying an invalid name filter', () => {
-            return prop.getProperties('property1').then((r) => {
-                expect(r).not.toBeDefined();
-            }).catch(() => {});
+            const success = jest.fn();
+            return prop.getProperties('property1').then(() => {
+                success();
+                throw new Error('Promise was resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
         });
         it('can fetch a single property', () => {
             return prop.getProperty('mindtouch.import#info');

--- a/__tests__/pagePropertyBase.test.js
+++ b/__tests__/pagePropertyBase.test.js
@@ -1,0 +1,27 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-env jasmine, jest */
+jest.unmock('../pagePropertyBase.js');
+import { PagePropertyBase } from '../pagePropertyBase.js';
+
+describe('Page Property Base', () => {
+    it('can not construct a PagePropertyBase object directly', () => {
+        expect(() => new PagePropertyBase()).toThrowError(TypeError);
+    });
+});

--- a/draftProperty.js
+++ b/draftProperty.js
@@ -1,0 +1,10 @@
+import { Plug } from 'mindtouch-http.js/plug.js';
+import { PagePropertyBase } from './pagePropertyBase.js';
+import { Settings } from './lib/settings.js';
+
+export class DraftProperty extends PagePropertyBase {
+    constructor(id, settings = new Settings()) {
+        super(id);
+        this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'drafts', this._id, 'properties');
+    }
+}

--- a/pageProperty.js
+++ b/pageProperty.js
@@ -1,14 +1,11 @@
 import { Plug } from 'mindtouch-http.js/plug.js';
+import { PagePropertyBase } from './pagePropertyBase.js';
 import { Settings } from './lib/settings.js';
-import { utility } from './lib/utility.js';
-import { modelParser } from './lib/modelParser.js';
-import { pagePropertiesModel } from './models/pageProperties.model.js';
-import { pagePropertyModel } from './models/pageProperty.model.js';
 
 /**
  * A class for managing the properties of a page.
  */
-export class PageProperty {
+export class PageProperty extends PagePropertyBase {
 
     /**
      * Construct a new PageProperty object.
@@ -16,50 +13,8 @@ export class PageProperty {
      * @param {Settings} [settings] - The {@link Settings} information to use in construction. If not supplied, the default settings are used.
      */
     constructor(id = 'home', settings = new Settings()) {
-        this._id = utility.getResourceId(id, 'home');
+        super(id);
         this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'pages', this._id, 'properties');
-    }
-
-    /**
-     * Get all of the properties of the page.
-     * @param {Array} [names=[]] - An array of names to fetch so that the results are filtered.
-     * @returns {Promise.<pagePropertiesModel>} - A Promise that, when resolved, yields a {@link pagePropertiesModel} object that contains the listing of properties.
-     */
-    getProperties(names = []) {
-        if(!Array.isArray(names)) {
-            return Promise.reject(new Error('The property names must be an array'));
-        }
-        let plug = this._plug;
-        if(names.length > 0) {
-            plug = plug.withParams({ names: names.join(',') });
-        }
-        let pagePropertiesModelParser = modelParser.createParser(pagePropertiesModel);
-        return plug.get().then((r) => r.json()).then(pagePropertiesModelParser);
-    }
-
-    /**
-     * Gets a single page property by property key.
-     * @param {String} key - The key of the property to fetch.
-     * @returns {Promise.<pagePropertyModel>} - A Promise that, when resolved, yields a {@link pagePropertyModel} object that contains the property information.
-     */
-    getProperty(key) {
-        if(!key) {
-            return Promise.reject(new Error('Attempting to fetch a page property without providing a property key'));
-        }
-        let pagePropertyModelParser = modelParser.createParser(pagePropertyModel);
-        return this._plug.at(encodeURIComponent(key), 'info').get().then((r) => r.json()).then(pagePropertyModelParser);
-    }
-
-    /**
-     * Get the contents of a page property.
-     * @param {String} key - The key of the property to fetch.
-     * @returns {Promise} - A Promise that, when resolved, yields the property contents.  The property can be of any type allowed by the MindTouch property subsystem.
-     */
-    getPropertyContents(key) {
-        if(!key) {
-            return Promise.reject(new Error('Attempting to fetch a page property contents without providing a property key'));
-        }
-        return this._plug.at(encodeURIComponent(key)).get();
     }
 
     /**
@@ -73,27 +28,5 @@ export class PageProperty {
             return Promise.reject(new Error('Attempting to fetch properties for children without providing a property key'));
         }
         return this._plug.withParams({ depth: depth, names: key }).get().then((r) => r.json());
-    }
-
-    /**
-     * Set a property on the page
-     * @param {String} key - The key of the property to set
-     * @param {Object} value - An object conteining information regarding the value to set.
-     * @param {String} value.text - The string value representing the property value to set.
-     * @param {String} [value.type=@see utility.textRequestType] - The mime type of the value's text field.
-     * @param {Object} params - An object that contains values that will direct the behavior of the operation.
-     * @returns {Promise} - A Promise that, when resolved, indicates the property was set successfully.
-     */
-    setProperty(key, value = { }, params = { abort: 'modified' }) {
-        if(!key) {
-            return Promise.reject(new Error('Attempting to set a property without providing a property key'));
-        }
-        if(!value.text) {
-            return Promise.reject(new Error('Attempting to set a property without providing a property value'));
-        }
-        if(!value.type) {
-            value.type = utility.textRequestType;
-        }
-        return this._plug.at(encodeURIComponent(key)).withParams(params).put(value.text, value.type);
     }
 }

--- a/pagePropertyBase.js
+++ b/pagePropertyBase.js
@@ -1,0 +1,75 @@
+import { utility } from './lib/utility.js';
+import { modelParser } from './lib/modelParser.js';
+import { pagePropertiesModel } from './models/pageProperties.model.js';
+import { pagePropertyModel } from './models/pageProperty.model.js';
+
+export class PagePropertyBase {
+    constructor(id) {
+        if(this.constructor.name === 'PagePropertyBase') {
+            throw new TypeError('PagePropertyBase must not be constructed directly.  Use one of PageProperty() or DraftProperty()');
+        }
+        this._id = utility.getResourceId(id, 'home');
+    }
+
+    /**
+     * Get all of the properties of the page.
+     * @param {Array} [names=[]] - An array of names to fetch so that the results are filtered.
+     * @returns {Promise.<pagePropertiesModel>} - A Promise that, when resolved, yields a {@link pagePropertiesModel} object that contains the listing of properties.
+     */
+    getProperties(names = []) {
+        if(!Array.isArray(names)) {
+            return Promise.reject(new Error('The property names must be an array'));
+        }
+        let plug = this._plug;
+        if(names.length > 0) {
+            plug = plug.withParams({ names: names.join(',') });
+        }
+        return plug.get().then((r) => r.json()).then(modelParser.createParser(pagePropertiesModel));
+    }
+
+    /**
+     * Get the contents of a page property.
+     * @param {String} key - The key of the property to fetch.
+     * @returns {Promise} - A Promise that, when resolved, yields the property contents.  The property can be of any type allowed by the MindTouch property subsystem.
+     */
+    getPropertyContents(key) {
+        if(!key) {
+            return Promise.reject(new Error('Attempting to fetch a page property contents without providing a property key'));
+        }
+        return this._plug.at(encodeURIComponent(key)).get();
+    }
+
+    /**
+     * Gets a single page property by property key.
+     * @param {String} key - The key of the property to fetch.
+     * @returns {Promise.<pagePropertyModel>} - A Promise that, when resolved, yields a {@link pagePropertyModel} object that contains the property information.
+     */
+    getProperty(key) {
+        if(!key) {
+            return Promise.reject(new Error('Attempting to fetch a page property without providing a property key'));
+        }
+        return this._plug.at(encodeURIComponent(key), 'info').get().then((r) => r.json()).then(modelParser.createParser(pagePropertyModel));
+    }
+
+    /**
+     * Set a property on the page
+     * @param {String} key - The key of the property to set
+     * @param {Object} value - An object conteining information regarding the value to set.
+     * @param {String} value.text - The string value representing the property value to set.
+     * @param {String} [value.type=@see utility.textRequestType] - The mime type of the value's text field.
+     * @param {Object} params - An object that contains values that will direct the behavior of the operation.
+     * @returns {Promise} - A Promise that, when resolved, indicates the property was set successfully.
+     */
+    setProperty(key, value = { }, params = { abort: 'modified' }) {
+        if(!key) {
+            return Promise.reject(new Error('Attempting to set a property without providing a property key'));
+        }
+        if(!value.text) {
+            return Promise.reject(new Error('Attempting to set a property without providing a property value'));
+        }
+        if(!value.type) {
+            value.type = utility.textRequestType;
+        }
+        return this._plug.at(encodeURIComponent(key)).withParams(params).put(value.text, value.type);
+    }
+}


### PR DESCRIPTION
Reviewed by @JeremyRH 

Draft page properties and live page properties share most functionality, but have different API URIs.
This creates the concept of a DraftProperty and moves the common functionality to PagePropertyBase