### PR TITLE
Add the siteReport.js module

### DIFF
--- a/__tests__/siteReports.errors.test.js
+++ b/__tests__/siteReports.errors.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jasmine, jest */
+jest.unmock('mindtouch-http.js/plug.js');
+jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/plug.js'));
+jest.unmock('mindtouch-http.js/progressPlug.js');
+jest.mock('mindtouch-http.js/progressPlug.js', () => require.requireActual('../__mocks__/progressPlug.js'));
+
+jest.unmock('../siteReports.js');
+
+describe('Error handling for the siteReports.js module', () => {
+    it('can get through virtual page checking when there is another failure (no responseText)', () => {
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            get() {
+                return Promise.reject({ message: 'Bad Request', status: 400, responseText: '{}' });
+            }
+        }));
+        const SiteReports = require('../siteReports.js').SiteReports;
+        const sr = new SiteReports();
+        const success = jest.fn();
+        return sr.getSiteHealth().then(() => {
+            success();
+            throw new Error('Promise resolved');
+        }).catch(() => {
+            expect(success).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/__tests__/siteReports.test.js
+++ b/__tests__/siteReports.test.js
@@ -1,0 +1,60 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-env jasmine, jest */
+jest.unmock('../siteReports.js');
+import { SiteReports } from '../siteReports.js';
+
+describe('Site Reports', () => {
+    describe('constructor', () => {
+        it('can create a new SiteReports object', () => {
+            const sr = new SiteReports();
+            expect(sr).toBeDefined();
+        });
+    });
+    describe('operations', () => {
+        let sr;
+        beforeEach(() => {
+            sr = new SiteReports();
+        });
+        it('can get the site health report (no params)', () => {
+            return sr.getSiteHealth();
+        });
+        it('can get the site health report (all params)', () => {
+            return sr.getSiteHealth({ analyzers: [ 'foo' ], severities: [ 'error' ] });
+        });
+        it('can fail with an invalid `analyzers` parameter', () => {
+            const success = jest.fn();
+            return sr.getSiteHealth({ analyzers: 'foo' }).then(() => {
+                success();
+                throw new Error('The promise was resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail with an invalid `severities` parameter', () => {
+            const success = jest.fn();
+            return sr.getSiteHealth({ severities: 'foo' }).then(() => {
+                success();
+                throw new Error('The promise was resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/models/siteHealthReport.model.js
+++ b/models/siteHealthReport.model.js
@@ -1,0 +1,36 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const siteHealthReportModel = [
+    {
+        field: 'inspections',
+        isArray: true,
+        transform: [
+            { field: '@severity', name: 'severity' },
+            { field: '@type', name: 'type' },
+            { field: 'message' },
+            {
+                field: 'page',
+                transform: [
+                    { field: '@uri', name: 'uri' },
+                    { field: '@id', name: 'id', transform: 'number' }
+                ]
+            }
+        ]
+    }
+];

--- a/site.js
+++ b/site.js
@@ -218,8 +218,9 @@ export class Site {
      * @param {Array} options.constraints.tags An array of tags to only consider when returning page results.
      * @param {Array} options.constraints.namespaces An array of namespaces to limit the results by.
      * @param {Boolean} [options.verbose=true] Show verbose page xml
+     * @param {String} [options.parser='bestguess'] - The parser to use for the query. Must be one of "bestguess", "term", "filename", "lucene"
      */
-    searchIndex({ q = '', limit = 100, offset = 0, sortBy = '-score', constraintString = null, constraints = {}, verbose = true } = {}) {
+    searchIndex({ q = '', limit = 100, offset = 0, sortBy = '-score', constraintString = null, constraints = {}, verbose = true, parser = 'bestguess' } = {}) {
         if(typeof limit === 'string') {
             if(limit !== 'all') {
                 return Promise.reject(new Error('The limit for index searching must be a number or "all"'));
@@ -231,7 +232,8 @@ export class Site {
             offset,
             sortby: sortBy,
             constraint: constraintString || _buildSearchConstraints(constraints),
-            verbose
+            verbose,
+            parser
         };
         return this.plug.at('search').withParams(searchParams).get().then((r) => r.json()).then(modelParser.createParser(searchModel));
     }

--- a/siteReports.js
+++ b/siteReports.js
@@ -1,0 +1,39 @@
+import { Plug } from 'mindtouch-http.js/plug.js';
+import { Settings } from './lib/settings.js';
+import { modelParser } from './lib/modelParser.js';
+import { apiErrorModel } from './models/apiError.model.js';
+import { siteHealthReportModel } from './models/siteHealthReport.model.js';
+
+const _errorParser = modelParser.createParser(apiErrorModel);
+
+export class SiteReports {
+    constructor(settings = new Settings()) {
+        this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'site', 'reports');
+    }
+
+    /**
+     * Get the site health report.
+     * @param {Object} [options]
+     * @param {Array} [options.analyzers] - An array of analyzers to include in the report (all analyzers included if none specified)
+     * @param {Array} [options.severities] - An array of severity levels to include in the report (all error levels if none specified)
+     */
+    getSiteHealth(options = {}) {
+        const params = {};
+        if(options.analyzers) {
+            if(!Array.isArray(options.analyzers)) {
+                return Promise.reject(new Error('The `analyzers` option must be an array of analyzers'));
+            }
+            params.analyzers = options.analyzers.join(',');
+        }
+        if(options.severities) {
+            if(!Array.isArray(options.severities)) {
+                return Promise.reject(new Error('The `severities` option must be an array of analyzers'));
+            }
+            params.severity = options.severities.join(',');
+        }
+        return this._plug.at('sitehealth').withParams(params).get()
+            .catch((err) => Promise.reject(_errorParser(err)))
+            .then((r) => r.json())
+            .then(modelParser.createParser(siteHealthReportModel));
+    }
+}

--- a/user.js
+++ b/user.js
@@ -170,6 +170,7 @@ export class UserManager {
      * @param {String} constraints.username - Search for users name starting with supplied text
      * @param {Number} constraints.roleid - Search for users of a specific role ID.
      * @param {Number} constraints.limit - Maximum number of items to retrieve. Actual maximum is capped by site setting
+     * @param {String} constraints.format - Output format. Must be one of "autocomplete", "default" , or "verbose"
      * @returns {Promise.<userListModel>} - A Promise that, when resolved, returns a {@link userListModel} containing the list of found users.
      */
     searchUsers(constraints) {


### PR DESCRIPTION
Reviewed by @killsunday 

- Add siteReports.js (currently only fetches the site health report)
- Add the `parser` parameter to Site.prototype.searchIndex
- Add the `format` parameter to UserManager.prototype.searchUsers