### PR TITLE
Create site jobs module with import/export scheduling

### DIFF
--- a/__tests__/siteJobs.errors.test.js
+++ b/__tests__/siteJobs.errors.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jasmine, jest */
+jest.unmock('mindtouch-http.js/plug.js');
+jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/plug.js'));
+jest.unmock('mindtouch-http.js/progressPlug.js');
+jest.mock('mindtouch-http.js/progressPlug.js', () => require.requireActual('../__mocks__/progressPlug.js'));
+
+jest.unmock('../siteJobs.js');
+
+describe('Error handling for the siteJobs.js module', () => {
+    it('can fail if the response to getting the jobs statuses is an error', () => {
+        jest.mock('mindtouch-http.js/plug.js', () => require.requireActual('../__mocks__/customPlug.js')({
+            get() {
+                return Promise.reject({ message: 'Bad Request', status: 400, responseText: '{}' });
+            }
+        }));
+        const SiteJobs = require('../siteJobs.js').SiteJobs;
+        const sr = new SiteJobs();
+        const success = jest.fn();
+        return sr.getJobsStatuses().then(() => {
+            success();
+            throw new Error('Promise resolved');
+        }).catch(() => {
+            expect(success).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/__tests__/siteJobs.test.js
+++ b/__tests__/siteJobs.test.js
@@ -1,0 +1,180 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-env jest, jasmine */
+jest.unmock('../siteJobs.js');
+import { SiteJobs } from '../siteJobs.js';
+
+describe('Site Jobs', () => {
+    describe('constructor', () => {
+        it('can create a new SiteJobs object', () => {
+            const sj = new SiteJobs();
+            expect(sj).toBeDefined();
+        });
+    });
+    describe('jobs operations', () => {
+        let sj = null;
+        beforeEach(() => {
+            sj = new SiteJobs();
+        });
+        afterEach(() => {
+            sj = null;
+        });
+        it('can get the jobs status', () => {
+            return sj.getJobsStatuses();
+        });
+    });
+    describe('export scheduler', () => {
+        let sj = null;
+        beforeEach(() => {
+            sj = new SiteJobs();
+        });
+        afterEach(() => {
+            sj = null;
+        });
+        it('can schedule an export job (all params)', () => {
+            const exportParams = {
+                email: 'foo@bar.com',
+                url: 'http://www.example.com',
+                pages: [
+                    { path: 'path/to/page/1', id: 1, includeSubpages: true },
+                    { path: 'path/to/page/2', id: 2, includeSubpages: false }
+                ]
+            };
+            return sj.scheduleExport(exportParams);
+        });
+        it('can schedule an export job (page path only)', () => {
+            const exportParams = {
+                url: 'http://www.example.com',
+                pages: [ { path: 'path/to/page/1' } ]
+            };
+            return sj.scheduleExport(exportParams);
+        });
+        it('can schedule an export job (page ID only)', () => {
+            const exportParams = {
+                email: 'foo@bar.com',
+                pages: [ { id: 1 } ]
+            };
+            return sj.scheduleExport(exportParams);
+        });
+        it('can fail when scheduling an export with missing options', () => {
+            const success = jest.fn();
+            return sj.scheduleExport().then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail when scheduling an export with missing notification options', () => {
+            const success = jest.fn();
+            return sj.scheduleExport({}).then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail when scheduling an export with missing pages option', () => {
+            const success = jest.fn();
+            return sj.scheduleExport({ email: 'foo@bar.com' }).then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail when scheduling an export with a non-array pages option', () => {
+            const success = jest.fn();
+            return sj.scheduleExport({ email: 'foo@bar.com', pages: 'this is clearly a string' }).then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+    });
+    describe('import scheduler', () => {
+        let sj = null;
+        beforeEach(() => {
+            sj = new SiteJobs();
+        });
+        afterEach(() => {
+            sj = null;
+        });
+        it('can schedule an import job (all params)', () => {
+            const importParams = {
+                email: 'foo@bar.com',
+                url: 'http://www.example.com',
+                archiveUrl: 'http://www.example.org',
+                dryRun: true
+            };
+            return sj.scheduleImport(importParams);
+        });
+        it('can schedule an import job (email only)', () => {
+            const importParams = {
+                email: 'foo@bar.com',
+                archiveUrl: 'http://www.example.org'
+            };
+            return sj.scheduleImport(importParams);
+        });
+        it('can schedule an import job (url only)', () => {
+            const importParams = {
+                url: 'http://bar.com',
+                archiveUrl: 'http://www.example.org'
+            };
+            return sj.scheduleImport(importParams);
+        });
+        it('can fail when scheduling an import with missing options', () => {
+            const success = jest.fn();
+            return sj.scheduleImport().then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail when scheduling an export with missing notification options', () => {
+            const success = jest.fn();
+            return sj.scheduleImport({}).then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail when scheduling an import with missing archiveUrl option', () => {
+            const success = jest.fn();
+            return sj.scheduleImport({ email: 'foo@bar.com' }).then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+        it('can fail when scheduling an import with invalid archiveUrl option', () => {
+            const success = jest.fn();
+            return sj.scheduleImport({ email: 'foo@bar.com', archiveUrl: '' }).then(() => {
+                success();
+                throw new Error('Promise resolved');
+            }).catch(() => {
+                expect(success).not.toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/lib/__tests__/settings.test.js
+++ b/lib/__tests__/settings.test.js
@@ -34,19 +34,23 @@ describe('Settings', () => {
         });
         it('can get and set the defaults', () => {
             Settings.default.host = 'http://www.example.com';
+            Settings.default.origin = 'http://www.example.org';
             Settings.default.token = 'abcd1234';
             Settings.default.headers = { Authorizarion: 'Basic ABDC1234' };
             Settings.default.queryParams = { 'dream.in.format': 'xml' };
             let defSettings = new Settings();
             Settings.default.host = 'http://example.com';
+            Settings.default.origin = 'http://example.org';
             Settings.default.token = 'efgh5678';
             Settings.default.headers = {};
             Settings.default.queryParams = {};
             expect(defSettings.host).toBe('http://www.example.com');
+            expect(defSettings.origin).toBe('http://www.example.org');
             expect(defSettings.token).toBe('abcd1234');
             expect(defSettings.plugConfig.uriParts).toEqual({ query: { 'dream.in.format': 'xml' } });
             expect(defSettings.plugConfig.headers).toEqual({ Authorizarion: 'Basic ABDC1234' });
             expect(Settings.default.host).toBe('http://example.com');
+            expect(Settings.default.origin).toBe('http://example.org');
             expect(Settings.default.token).toBe('efgh5678');
             expect(Settings.default.headers).toEqual({});
             expect(Settings.default.queryParams).toEqual({});
@@ -54,11 +58,10 @@ describe('Settings', () => {
         it('can create a settings object', () => {
             let settings = new Settings({
                 host: 'http://www.example.com',
-                origin: 'http://foo.com',
                 queryParams: { foo: 'bar' }
             });
             expect(settings.host).toBe('http://www.example.com');
-            expect(settings.origin).toBe('http://foo.com');
+            expect(settings.origin).toBe(null);
             expect(settings.plugConfig.uriParts).toEqual({ query: { foo: 'bar' } });
             expect(typeof settings.plugConfig.beforeRequest).toBe('function');
         });

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -18,6 +18,7 @@
  */
 import { Uri } from 'mindtouch-http.js/uri.js';
 let _defaultHost = '/';
+let _defaultOrigin = null;
 let _defaultQueryParams = { 'dream.out.format': 'json' };
 let _defaultHeaders = { 'X-Deki-Client': 'mindtouch-martian' };
 let _defaultToken = null;
@@ -50,6 +51,12 @@ export class Settings {
             set host(host) {
                 _defaultHost = host;
             },
+            get origin() {
+                return _defaultOrigin;
+            },
+            set origin(origin) {
+                _defaultOrigin = origin;
+            },
             get headers() {
                 return _defaultHeaders;
             },
@@ -67,10 +74,11 @@ export class Settings {
                 _defaultQueryParams = { 'dream.out.format': 'json' };
                 _defaultToken = null;
                 _defaultHeaders = { 'X-Deki-Client': 'mindtouch-martian' };
+                _defaultOrigin = null;
             }
         };
     }
-    constructor({ host = _defaultHost, queryParams = _defaultQueryParams, headers = _defaultHeaders, token = _defaultToken, origin = null } = {}) {
+    constructor({ host = _defaultHost, queryParams = _defaultQueryParams, headers = _defaultHeaders, token = _defaultToken, origin = _defaultOrigin } = {}) {
         this._host = host;
         this._token = token;
         this._origin = origin;

--- a/models/siteJob.model.js
+++ b/models/siteJob.model.js
@@ -1,0 +1,33 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { userModel } from './user.model.js';
+
+const siteJobModel = [
+    { field: '@id', name: 'id' },
+    { field: '@type', name: 'type' },
+    { field: '@status', name: 'status' },
+    { field: 'lastmodified', name: 'lastModified', transform: 'date' },
+    { field: 'submitted', transform: 'date' },
+    { field: 'user', transform: userModel }
+];
+const siteJobsModel = [
+    { field: 'job', name: 'jobs', isArray: true, transform: siteJobModel }
+];
+
+export { siteJobModel, siteJobsModel };

--- a/siteJobs.js
+++ b/siteJobs.js
@@ -1,0 +1,129 @@
+import { Plug } from 'mindtouch-http.js/plug.js';
+import { Settings } from './lib/settings.js';
+import { modelParser } from './lib/modelParser.js';
+import { utility } from './lib/utility.js';
+import { apiErrorModel } from './models/apiError.model.js';
+import { siteJobModel, siteJobsModel } from './models/siteJob.model.js';
+
+const _errorParser = modelParser.createParser(apiErrorModel);
+
+export class SiteJobs {
+
+    /**
+     * Create a new SiteImportExport object.
+     */
+    constructor(settings = new Settings()) {
+        this._plug = new Plug(settings.host, settings.plugConfig).at('@api', 'deki', 'site');
+    }
+
+    /**
+     * Schedules a site export.
+     * @param {Object} options - Options to configure the export job.
+     * @param {String} [options.email] - The email address to notify when the job completes. Required if a URL is not supplied.
+     * @param {String} [options.url] - The URL to notify when the job completes. Required if an email address is not supplied.
+     * @param {Object[]} [options.pages] - An array of objects with information about the pages to export.
+     * @param {Number} [options.pages[].id] - The ID of a page to export. Required if the path is not supplied.
+     * @param {String} [options.pages[].path] - The path of a page to export. Required if the ID is not supplied.
+     * @param {Boolean} [options.pages[].includeSubpages] - Idicates whether or not to export the subpages of the specified page.
+     */
+    scheduleExport(options) {
+        if(!options) {
+            return Promise.reject(new Error('The export options must be supplied'));
+        }
+        let notificationSupplied = false;
+        if('email' in options) {
+            notificationSupplied = true;
+        }
+        if('url' in options) {
+            notificationSupplied = true;
+        }
+        if(notificationSupplied === false) {
+            return Promise.reject(new Error('Notification email and url are missing. Need an email or url to notify when the job completes.'));
+        }
+        if('pages' in options) {
+            if(!Array.isArray(options.pages)) {
+                return Promise.reject('The pages option must be an array.');
+            }
+        } else {
+            return Promise.reject('One or more pages must be specified for export.');
+        }
+        const pagesElements = options.pages.reduce((acc, page) => {
+            let element = '<page';
+            if(page.id) {
+                element += ` id="${page.id}"`;
+            }
+            if('includeSubpages' in page) {
+                element += ` includesubpages="${page.includeSubpages}"`;
+            }
+            element += '>';
+            if(page.path) {
+                element += `<path>${page.path}</path>`;
+            }
+            element += '</page>';
+            return acc + element;
+        }, '');
+        let postData = '<job><notification>';
+        if(options.email) {
+            postData += `<email>${options.email}</email>`;
+        }
+        if(options.url) {
+            postData += `<url>${options.url}</url>`;
+        }
+        postData += '</notification>';
+        postData += `<pages>${pagesElements}</pages>`;
+        postData += '</job>';
+        return this._plug.at('jobs', 'export').post(postData, utility.xmlRequestType)
+            .then((r) => r.json())
+            .then(modelParser.createParser(siteJobModel));
+    }
+
+    /**
+     * Schedules a site import
+     * @param {Object} options - Options to configure the import job.
+     * @param {Boolean} [options.dryRun=false] - Perform a dry run of the import to diagnose potential content problems.
+     * @param {String} [options.email] - The email address to notify when the job completes. Required if a URL is not supplied.
+     * @param {String} [options.url] - The URL to notify when the job completes. Required if an email address is not supplied.
+     * @param {String} options.archiveUrl - The URL pointing to the archive to import.
+     */
+    scheduleImport(options) {
+        if(!options) {
+            return Promise.reject(new Error('The export options must be supplied'));
+        }
+        let notificationSupplied = false;
+        if('email' in options) {
+            notificationSupplied = true;
+        }
+        if('url' in options) {
+            notificationSupplied = true;
+        }
+        if(notificationSupplied === false) {
+            return Promise.reject(new Error('Notification email and url are missing. Need an email or url to notify when the job completes.'));
+        }
+        if(typeof options.archiveUrl !== 'string' || options.archiveUrl === '') {
+            return Promise.reject(new Error('An archive url is required, and must be a non-empty string to perform an import.'));
+        }
+        let postData = '<job><notification>';
+        if(options.email) {
+            postData += `<email>${options.email}</email>`;
+        }
+        if(options.url) {
+            postData += `<url>${options.url}</url>`;
+        }
+        postData += '</notification>';
+        postData += `<archive><url>${options.archiveUrl}</url></archive>`;
+        postData += '</job>';
+        return this._plug.at('jobs', 'import').withParam('dryrun', Boolean(options.dryRun)).post(postData, utility.xmlRequestType)
+            .then((r) => r.json())
+            .then(modelParser.createParser(siteJobModel));
+    }
+
+    /**
+     * Gets the job statuses for a site.
+     */
+    getJobsStatuses() {
+        return this._plug.at('jobs', 'status').get()
+            .catch((err) => Promise.reject(_errorParser(err)))
+            .then((r) => r.json())
+            .then(modelParser.createParser(siteJobsModel));
+    }
+}


### PR DESCRIPTION
Reviewed by @JeremyRH 

Add siteJobs.js with the following functions:
- scheduleExport
- scheduleImport
- getJobsStatuses

Add the `origin` parameter as a set-able field on martian settings