### PR TITLE
Fix API date parsing for zero-based months

### DIFF
--- a/lib/__tests__/modelParser.test.js
+++ b/lib/__tests__/modelParser.test.js
@@ -43,14 +43,32 @@ describe('Model Parser', () => {
         it('thows converting to date', () => {
             expect(() => modelParser.to.date('')).toThrow();
         });
-        it('returns a valid API-formatted date', () => {
-            const apiDate14 = modelParser.to.apiDate('20160101120059');
+        it('returns a valid API-formatted date (14 places)', () => {
+            const apiDate14 = modelParser.to.apiDate('20160120120059');
             expect(apiDate14 instanceof Date).toBe(true);
-            const apiDate8 = modelParser.to.apiDate('20160101');
+            expect(apiDate14.getFullYear()).toBe(2016);
+            expect(apiDate14.getMonth()).toBe(0);
+            expect(apiDate14.getDate()).toBe(20);
+            expect(apiDate14.getHours()).toBe(12);
+            expect(apiDate14.getMinutes()).toBe(0);
+            expect(apiDate14.getSeconds()).toBe(59);
+            expect(apiDate14.toString()).toMatch('Jan 20 2016 12:00:59');
+        });
+        it('returns a valid API-formatted date (8 places)', () => {
+            const apiDate8 = modelParser.to.apiDate('20161112');
             expect(apiDate8 instanceof Date).toBe(true);
+            expect(apiDate8.getFullYear()).toBe(2016);
+            expect(apiDate8.getMonth()).toBe(10);
+            expect(apiDate8.getDate()).toBe(12);
+            expect(apiDate8.toString()).toMatch('Nov 12 2016');
         });
         it('throws an error for an invalid API-formatted date', () => {
             expect(() => modelParser.to.apiDate('201601011200')).toThrow();
+            expect(() => modelParser.to.apiDate('')).toThrow();
+            expect(() => modelParser.to.apiDate('201601011200cc')).toThrow();
+            expect(() => modelParser.to.apiDate('2016010112cc00')).toThrow();
+            expect(() => modelParser.to.apiDate('20160101123c00')).toThrow();
+            expect(() => modelParser.to.apiDate('xxxx0101120059')).toThrow();
         });
         it('returns a valid integer', () => {
             let toInteger = modelParser.to.number('5');

--- a/lib/modelParser.js
+++ b/lib/modelParser.js
@@ -30,8 +30,8 @@ export const modelParser = {
             return dateValue;
         },
         apiDate(value) {
-            if(value.length !== 14 && value.length !== 8) {
-                throw new Error('Failed converting an API date: The raw value must be a string of length 8 or 14');
+            if(!(/^\d{8}$|^\d{14}$/).test(value)) {
+                throw new Error('Failed converting an API date: The raw value must be a string of digits and of length 8 or 14');
             }
             const parts = [
                 value.slice(0, 4),
@@ -40,7 +40,10 @@ export const modelParser = {
                 value.slice(8, 10),
                 value.slice(10, 12),
                 value.slice(12)
-            ];
+            ].map((p) => parseInt(p, 10)).filter((p) => !isNaN(p));
+
+            // The month parameter is zero-based, so we'll need to decrement it before constructing the Date.
+            parts[1]--;
             return new Date(...parts);
         },
         number(value) {


### PR DESCRIPTION
Reviewed by @JeremyRH 

- Add a regex to the API date parser to validate that the length is correct and that the string contains all digits
- decrement the month param before sending to the Date constructor (months are zero-based, but the date string specifies them as 1-based)