### PR TITLE
Add getPopularPages to PageManager

### DIFF
--- a/__tests__/page.test.js
+++ b/__tests__/page.test.js
@@ -511,6 +511,21 @@ describe('Page', () => {
                     return pm.getTemplates({ includeDescription: 'foo' }).catch(failed).then(() => expect(failed).toHaveBeenCalled());
                 });
             });
+            it('can get a list of popular pages (no params)', () => {
+                return pm.getPopularPages();
+            });
+            it('can get a list of popular pages (all params)', () => {
+                return pm.getPopularPages({ limit: 10, offset: 20 });
+            });
+            describe('popular pages failures', () => {
+                const failed = jest.fn();
+                afterEach(() => {
+                    failed.mockReset();
+                });
+                it('invalid options', () => {
+                    return pm.getPopularPages({ limit: 'foo', offset: true }).catch(failed).then(() => expect(failed).toHaveBeenCalled());
+                });
+            });
         });
     });
 });

--- a/models/__mocks__/popularPages/simple.mock.json
+++ b/models/__mocks__/popularPages/simple.mock.json
@@ -1,0 +1,64 @@
+{
+    "@count": "3",
+    "@href": "https://aaronm-elm.mindtouch.be/@api/deki/pages/popular",
+    "page": [
+        {
+            "@id": "1",
+            "@guid": "00000000000000000000000000000000",
+            "@draft.state": "inactive",
+            "@href": "https://aaronm-elm.mindtouch.be/@api/deki/pages/1?redirects=0",
+            "@deleted": "false",
+            "date.created": "Mon, 19 Dec 2016 17:22:45 GMT",
+            "language": "en-US",
+            "metrics": {
+                "metric.views": "690"
+            },
+            "namespace": "main",
+            "path": {
+                "@seo": "true",
+                "@type": "fixed",
+                "#text": ""
+            },
+            "title": "Home",
+            "uri.ui": "https://aaronm-elm.mindtouch.be/"
+        },
+        {
+            "@id": "299",
+            "@guid": "d54576b4e2eb4735a064060d5eef65e2",
+            "@draft.state": "inactive",
+            "@href": "https://aaronm-elm.mindtouch.be/@api/deki/pages/299?redirects=0",
+            "@deleted": "false",
+            "date.created": "Tue, 20 Dec 2016 21:38:32 GMT",
+            "language": "en-US",
+            "metrics": {
+                "metric.views": "511"
+            },
+            "namespace": "main",
+            "path": {
+                "@seo": "true",
+                "#text": "Category_1/Guide_1"
+            },
+            "title": "Guide 1",
+            "uri.ui": "https://aaronm-elm.mindtouch.be/Category_1/Guide_1"
+        },
+        {
+            "@id": "330",
+            "@guid": "bdd003b79b864c2594b1319264341072",
+            "@draft.state": "inactive",
+            "@href": "https://aaronm-elm.mindtouch.be/@api/deki/pages/330?redirects=0",
+            "@deleted": "false",
+            "date.created": "Wed, 11 Jan 2017 22:38:45 GMT",
+            "language": "en-US",
+            "metrics": {
+                "metric.views": "253"
+            },
+            "namespace": "main",
+            "path": {
+                "@seo": "true",
+                "#text": "Category_2/Guide_2/Topic_2.2"
+            },
+            "title": "Topic 2.2",
+            "uri.ui": "https://aaronm-elm.mindtouch.be/Category_2/Guide_2/Topic_2.2"
+        }
+    ]
+}

--- a/models/popularPages.model.js
+++ b/models/popularPages.model.js
@@ -1,0 +1,25 @@
+/**
+ * Martian - Core JavaScript API for MindTouch
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { pageModel } from './page.model.js';
+
+export const popularPagesModel = [
+    { field: '@count', name: 'count', transform: 'number' },
+    { field: '@href', name: 'href' },
+    { field: 'page', name: 'pages', isArray: 'true', transform: pageModel }
+];

--- a/page.js
+++ b/page.js
@@ -4,6 +4,7 @@ import { Settings } from './lib/settings.js';
 import { utility } from './lib/utility.js';
 import { modelParser } from './lib/modelParser.js';
 import { PageBase } from './pageBase.js';
+import { valid, required, one, equals, number } from './lib/validation.js';
 import { pageModel } from './models/page.model.js';
 import { subpagesModel } from './models/subpages.model.js';
 import { pageContentsModel } from './models/pageContents.model.js';
@@ -18,6 +19,7 @@ import { pageFindModel } from './models/pageFind.model.js';
 import { pageLinkDetailsModel } from './models/pageLinkDetails.model.js';
 import { healthReportModel } from './models/healthReport.model.js';
 import { templateListModel } from './models/templateList.model.js';
+import { popularPagesModel } from './models/popularPages.model.js';
 import { apiErrorModel } from './models/apiError.model.js';
 
 const _errorParser = modelParser.createParser(apiErrorModel);
@@ -490,5 +492,25 @@ export class PageManager {
         return this._plug.at('templates').withParams({ type, includeDescription }).get()
             .then((r) => r.json())
             .then(modelParser.createParser(templateListModel));
+    }
+
+    /**
+     * Retrieves a list of popular pages on the site.
+     * @param {Object} [options] Options to direct the fetching of the popular pages.
+     * @param {Number|String} [options.limit=50] The number of results to return. Can be set to the string "all" to return all results.
+     * @param {Number} [options.offset=0] The number of results to skip.
+     * @returns {Promise} A Promise that, when resolved, yields a listing of popular pages.
+     */
+    getPopularPages({ limit = 50, offset = 0 } = {}) {
+        const optionsErrors = valid.object({ limit, offset },
+            required('limit', one(number(), equals('all'))),
+            required('offset', number())
+        );
+        if(optionsErrors.length > 0) {
+            return Promise.reject(optionsErrors.join(', '));
+        }
+        return this._plug.at('popular').withParams({ limit, offset }).get()
+            .then((r) => r.json())
+            .then(modelParser.createParser(popularPagesModel));
     }
 }


### PR DESCRIPTION
Reviewed by @killsunday 
- Add PageManager.prototype.getPopularPages()
- Add popularPages model
- Add tests and mock