### PR TITLE
Remove -date from the sortBy parameter in /site/query call

### DIFF
--- a/site.js
+++ b/site.js
@@ -219,7 +219,7 @@ export class Site {
         const searchParams = {
             limit: limit,
             offset: offset,
-            sortBy: '-date,-rank',
+            sortBy: '-rank',
             q: q,
             summarypath: encodeURI(path),
             constraint: _buildSearchConstraints(constraint),


### PR DESCRIPTION
reviewed by: @aaronmars 

- set a proper default for /site/query