### PR TITLE
update search to include session id passthrough.

### DIFF
--- a/__tests__/site.test.js
+++ b/__tests__/site.test.js
@@ -81,7 +81,7 @@ describe('Site API', () => {
                 return site.search({ q: 'search term', namespaces: 'template' });
             });
             it('can perform a search with all parameters', () => {
-                return site.search({ path: '/foo/bar', tags: 'abc', type: 'wiki', offset: 123, limit: 10, q: 'search term', namespaces: [ 'main', 'template' ] });
+                return site.search({ path: '/foo/bar', tags: 'abc', type: 'wiki', offset: 123, limit: 10, q: 'search term', namespaces: [ 'main', 'template' ], sessionid: 'foo' });
             });
         });
         describe('search index tests', () => {

--- a/models/__mocks__/search/query.mock.json
+++ b/models/__mocks__/search/query.mock.json
@@ -1,6 +1,7 @@
 {
     "@ranking": "adaptive",
     "@queryid": "2369",
+    "@sessionid": "bar",
     "@querycount": "28",
     "@count.recommendations": "0",
     "@count": "25",

--- a/models/search.model.js
+++ b/models/search.model.js
@@ -21,6 +21,7 @@ import { pageModel } from './page.model.js';
 export const searchModel = [
     { field: '@ranking', name: 'ranking' },
     { field: '@queryid', name: 'queryId', transform: 'number' },
+    { field: '@sessionid', name: 'sessionId' },
     { field: '@querycount', name: 'queryCount', transform: 'number' },
     { field: '@count.recommendations', name: 'recommendationCount', transform: 'number' },
     { field: '@count', name: 'count', transform: 'number' },

--- a/site.js
+++ b/site.js
@@ -201,10 +201,11 @@ export class Site {
      * @param {String} [q=''] - Search keywords or advanced search syntax.
      * @param {String} [path=''] - A page path to constrain the search results to items located under the specified path.
      * @param {String|Array} [namespace='main'] - A comma-separated list or array of namespaces to filter the results by. Valid namespaces: 'main', 'template', 'user'.
+     * @param {String} [sessionid=null] - An identifier to know that the query is grouped with the previous query.
      * @param {Boolean} [recommendations=true] - `true` to include recommended search results based off site configuration. `false` to suppress them.
      * @returns {Promise.<searchModel>} - A Promise that, when resolved, yields the results from the search in a {@link searchModel}.
      */
-    search({ limit = 10, offset = 0, q = '', path = '', recommendations = true, tags = '', type = '', namespaces = 'main' } = {}) {
+    search({ limit = 10, offset = 0, q = '', path = '', recommendations = true, tags = '', type = '', namespaces = 'main', sessionid = null } = {}) {
         const constraint = {};
         if(path !== '' && path !== '/') {
             constraint.path = path;
@@ -225,6 +226,9 @@ export class Site {
             constraint: _buildSearchConstraints(constraint),
             recommendations: recommendations
         };
+        if(sessionid) {
+            searchParams.sessionid = sessionid;
+        }
         return this.plug.at('query').withParams(searchParams).get().then((r) => r.json()).then(modelParser.createParser(searchModel));
     }
 


### PR DESCRIPTION
Reviewed by: @derekrobbins  

Add session id parameter to search endpoint