### PR TITLE
Martian Test Cleanup

### DIFF
--- a/__tests__/api.errors.test.js
+++ b/__tests__/api.errors.test.js
@@ -2,12 +2,14 @@
 jest.unmock('../api.js');
 import { Api } from '../api.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -18,10 +20,10 @@ describe('API Module', () => {
     });
     it('can fail an HTTP request', async () => {
         expect.assertions(1);
-        return await expect(api.http()).rejects.toEqual(undefined);
+        return await expect(api.http()).rejects.toEqual(mockFailed);
     });
     it('can fail an F1 request', async () => {
         expect.assertions(1);
-        return await expect(api.f1()).rejects.toEqual(undefined);
+        return await expect(api.f1()).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/contextId.errors.test.js
+++ b/__tests__/contextId.errors.test.js
@@ -1,12 +1,14 @@
 /* eslint-env jasmine, jest */
 
+let mockFailed = 'MOCK FAILED';
+
 jest.unmock('../contextId.js');
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -23,11 +25,11 @@ describe('Context ID', () => {
         });
         it('can fail fetching all context maps', async () => {
             expect.assertions(1);
-            return await expect(cm.getMaps()).rejects.toEqual(undefined);
+            return await expect(cm.getMaps()).rejects.toEqual(mockFailed);
         });
         it('can fail fetching the list of all context definitions', async () => {
             expect.assertions(1);
-            return await expect(cm.getDefinitions()).rejects.toEqual(undefined);
+            return await expect(cm.getDefinitions()).rejects.toEqual(mockFailed);
         });
         it('can fail adding a context ID definition', async () => {
             expect.assertions(1);
@@ -41,15 +43,15 @@ describe('Context ID', () => {
         });
         it('can fail getting the definition info', async () => {
             expect.assertions(1);
-            return await expect(def.getInfo()).rejects.toEqual(undefined);
+            return await expect(def.getInfo()).rejects.toEqual(mockFailed);
         });
         it('can fail updating the description of a definintion', async () => {
             expect.assertions(1);
-            return await expect(def.updateDescription()).rejects.toEqual(undefined);
+            return await expect(def.updateDescription()).rejects.toEqual(mockFailed);
         });
         it('can fail deleting a definition', async () => {
             expect.assertions(1);
-            return await expect(def.delete()).rejects.toEqual(undefined);
+            return await expect(def.delete()).rejects.toEqual(mockFailed);
         });
     });
     describe('ContextMap instance functions', () => {
@@ -59,15 +61,15 @@ describe('Context ID', () => {
         });
         it('can fail getting the info of a map', async () => {
             expect.assertions(1);
-            return await expect(map.getInfo()).rejects.toEqual(undefined);
+            return await expect(map.getInfo()).rejects.toEqual(mockFailed);
         });
         it('can fail updating an existing map', async () => {
             expect.assertions(1);
-            return await expect(map.update(123)).rejects.toEqual(undefined);
+            return await expect(map.update(123)).rejects.toEqual(mockFailed);
         });
         it('can failing clearing a mapping', async () => {
             expect.assertions(1);
-            return await expect(map.remove()).rejects.toEqual(undefined);
+            return await expect(map.remove()).rejects.toEqual(mockFailed);
         });
     });
 });

--- a/__tests__/developerToken.errors.test.js
+++ b/__tests__/developerToken.errors.test.js
@@ -2,12 +2,14 @@
 import { developerTokensModel, developerTokenModel } from '../developerToken.js';
 jest.unmock('../developerToken.js');
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 const DT = require.requireActual('../developerToken.js');
@@ -29,7 +31,7 @@ describe('Developer Token Errors', () => {
         it('can fail if the get operation is rejected', async () => {
             const dtm = new DT.DeveloperTokenManager();
             expect.assertions(1);
-            return await expect(dtm.getTokens()).rejects.toEqual(undefined);
+            return await expect(dtm.getTokens()).rejects.toEqual(mockFailed);
         });
     });
 });

--- a/__tests__/developerToken.errors.test.js
+++ b/__tests__/developerToken.errors.test.js
@@ -1,5 +1,4 @@
 /* eslint-env jasmine, jest */
-import { developerTokensModel, developerTokenModel } from '../developerToken.js';
 jest.unmock('../developerToken.js');
 
 let mockFailed = 'MOCK FAILED';

--- a/__tests__/draft.errors.test.js
+++ b/__tests__/draft.errors.test.js
@@ -3,11 +3,13 @@ jest.unmock('../pageBase.js');
 jest.unmock('../draft.js');
 import { DraftManager, Draft } from '../draft.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../pageBase.js');
@@ -23,7 +25,7 @@ describe('Plug Error handling for the draft.js Draft Manager module', () => {
     });
     it('can fail to get drafts when an HTTP error is returned', async () => {
         expect.assertions(1);
-        return await expect(dm.getDrafts()).rejects.toEqual(undefined);
+        return await expect(dm.getDrafts()).rejects.toEqual(mockFailed);
     });
 });
 
@@ -34,18 +36,18 @@ describe('Plug Error handling for the draft.js Draft module', () => {
     });
     it('can fail to deactivate draft when an HTTP error is returned', async () => {
         expect.assertions(1);
-        return await expect(draft.deactivate()).rejects.toEqual(undefined);
+        return await expect(draft.deactivate()).rejects.toEqual(mockFailed);
     });
     it('can fail to publish drafts when an HTTP error is returned', async () => {
         expect.assertions(1);
-        return await expect(draft.publish()).rejects.toEqual(undefined);
+        return await expect(draft.publish()).rejects.toEqual(mockFailed);
     });
     it('can fail to unpublish drafts when an HTTP error is returned', async () => {
         expect.assertions(1);
-        return await expect(draft.unpublish()).rejects.toEqual(undefined);
+        return await expect(draft.unpublish()).rejects.toEqual(mockFailed);
     });
     it('can fail to set draft title when an HTTP error is returned', async () => {
         expect.assertions(1);
-        return await expect(draft.setTitle(123)).rejects.toEqual(undefined);
+        return await expect(draft.setTitle(123)).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/events.errors.test.js
+++ b/__tests__/events.errors.test.js
@@ -2,11 +2,13 @@
 jest.unmock('../events.js');
 import { Events } from '../events.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -17,75 +19,75 @@ describe('Events', () => {
     });
     it('can fail getting site drafts history logs', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteDraftsHistoryLogs()).rejects.toEqual(undefined);
+        return await expect(events.getSiteDraftsHistoryLogs()).rejects.toEqual(mockFailed);
     });
     it('can fail getting site drafts history log url', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteDraftsHistoryLogUrl(123)).rejects.toEqual(undefined);
+        return await expect(events.getSiteDraftsHistoryLogUrl(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting site drafts history', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteDraftsHistory()).rejects.toEqual(undefined);
+        return await expect(events.getSiteDraftsHistory()).rejects.toEqual(mockFailed);
     });
     it('can fail getting site drafts history detail', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteDraftsHistoryDetail('detailID')).rejects.toEqual(undefined);
+        return await expect(events.getSiteDraftsHistoryDetail('detailID')).rejects.toEqual(mockFailed);
     });
     it('can fail getting site draft history summary', async () => {
         expect.assertions(1);
-        return await expect(events.getDraftHistory()).rejects.toEqual(undefined);
+        return await expect(events.getDraftHistory()).rejects.toEqual(mockFailed);
     });
     it('can fail getting site draft history detail', async () => {
         expect.assertions(1);
-        return await expect(events.getDraftHistoryDetail(123, '123')).rejects.toEqual(undefined);
+        return await expect(events.getDraftHistoryDetail(123, '123')).rejects.toEqual(mockFailed);
     });
     it('can fail getting learning path history', async () => {
         expect.assertions(1);
-        return await expect(events.getLearningPathHistory('pathID')).rejects.toEqual(undefined);
+        return await expect(events.getLearningPathHistory('pathID')).rejects.toEqual(mockFailed);
     });
     it('can fail getting site history logs', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteHistoryLogs()).rejects.toEqual(undefined);
+        return await expect(events.getSiteHistoryLogs()).rejects.toEqual(mockFailed);
     });
     it('can fail getting site history log url', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteHistoryLogUrl(123)).rejects.toEqual(undefined);
+        return await expect(events.getSiteHistoryLogUrl(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting site history summary', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteHistory()).rejects.toEqual(undefined);
+        return await expect(events.getSiteHistory()).rejects.toEqual(mockFailed);
     });
     it('can fail getting site history detail', async () => {
         expect.assertions(1);
-        return await expect(events.getSiteHistoryDetail('detailID')).rejects.toEqual(undefined);
+        return await expect(events.getSiteHistoryDetail('detailID')).rejects.toEqual(mockFailed);
     });
     it('can fail getting log page view', async () => {
         expect.assertions(1);
-        return await expect(events.logPageView()).rejects.toEqual(undefined);
+        return await expect(events.logPageView()).rejects.toEqual(mockFailed);
     });
     it('can fail getting page history', async () => {
         expect.assertions(1);
-        return await expect(events.getPageHistory(123)).rejects.toEqual(undefined);
+        return await expect(events.getPageHistory(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting page history detail', async () => {
         expect.assertions(1);
-        return await expect(events.getPageHistoryDetail(123, 'test')).rejects.toEqual(undefined);
+        return await expect(events.getPageHistoryDetail(123, 'test')).rejects.toEqual(mockFailed);
     });
     it('can fail getting log search', async () => {
         expect.assertions(1);
-        return await expect(events.logSearch()).rejects.toEqual(undefined);
+        return await expect(events.logSearch()).rejects.toEqual(mockFailed);
     });
     it('can fail getting user activity logs', async () => {
         expect.assertions(1);
-        return await expect(events.getUserActivityLogs()).rejects.toEqual(undefined);
+        return await expect(events.getUserActivityLogs()).rejects.toEqual(mockFailed);
     });
     it('can fail getting user activity log url', async () => {
         expect.assertions(1);
-        return await expect(events.getUserActivityLogUrl(123)).rejects.toEqual(undefined);
+        return await expect(events.getUserActivityLogUrl(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting user activity summary', async () => {
         expect.assertions(1);
-        return await expect(events.getUserActivity(123)).rejects.toEqual(undefined);
+        return await expect(events.getUserActivity(123)).rejects.toEqual(mockFailed);
     });
     it('can fail if the API returns an error while getting User History', async () => {
         expect.assertions(1);
@@ -93,10 +95,10 @@ describe('Events', () => {
     });
     it('can fail getting user history detail', async () => {
         expect.assertions(1);
-        return await expect(events.getUserHistoryDetail(123)).rejects.toEqual(undefined);
+        return await expect(events.getUserHistoryDetail(123)).rejects.toEqual(mockFailed);
     });
     it('can fail logging a web widget impression', async () => {
         expect.assertions(1);
-        return await expect(events.logWebWidgetImpression()).rejects.toEqual(undefined);
+        return await expect(events.logWebWidgetImpression()).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/file.errors.progressPlug.js
+++ b/__tests__/file.errors.progressPlug.js
@@ -2,9 +2,11 @@
 jest.unmock('../file.js');
 import { File } from '../file.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/progressPlug.js', () =>
     require.requireActual('../__mocks__/customProgressPlug.js')({
-        put: () => Promise.reject()
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -15,6 +17,6 @@ describe('File API', () => {
     });
     it('can fail adding a file revision with no progress', async () => {
         expect.assertions(1);
-        return await expect(file.addRevision('fileObj', { progress: () => {} })).rejects.toEqual(undefined);
+        return await expect(file.addRevision('fileObj', { progress: () => {} })).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/file.errors.test.js
+++ b/__tests__/file.errors.test.js
@@ -2,12 +2,14 @@
 jest.unmock('../file.js');
 import { File } from '../file.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -18,23 +20,23 @@ describe('File API', () => {
     });
     it('can fail fetching file info', async () => {
         expect.assertions(1);
-        return await expect(file.getInfo()).rejects.toEqual(undefined);
+        return await expect(file.getInfo()).rejects.toEqual(mockFailed);
     });
     it('can fail fetching file revisions', async () => {
         expect.assertions(1);
-        return await expect(file.getRevisions()).rejects.toEqual(undefined);
+        return await expect(file.getRevisions()).rejects.toEqual(mockFailed);
     });
     it('can fail setting the file description', async () => {
         expect.assertions(1);
-        return await expect(file.setDescription()).rejects.toEqual(undefined);
+        return await expect(file.setDescription()).rejects.toEqual(mockFailed);
     });
     it('can fail deleting a file', async () => {
         expect.assertions(1);
-        return await expect(file.delete()).rejects.toEqual(undefined);
+        return await expect(file.delete()).rejects.toEqual(mockFailed);
     });
     it('can fail adding a file revision with no progress', async () => {
         expect.assertions(1);
-        return await expect(file.addRevision('fileObj')).rejects.toEqual(undefined);
+        return await expect(file.addRevision('fileObj')).rejects.toEqual(mockFailed);
     });
     it('can fail moving a file', async () => {
         expect.assertions(1);

--- a/__tests__/groups.errors.test.js
+++ b/__tests__/groups.errors.test.js
@@ -2,12 +2,14 @@
 jest.unmock('../group.js');
 import { GroupManager, Group } from '../group.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -27,7 +29,7 @@ describe('Group API', () => {
                     offset: 100,
                     sortBy: 'id'
                 })
-            ).rejects.toEqual(undefined);
+            ).rejects.toEqual(mockFailed);
         });
     });
     describe('Group', () => {
@@ -40,15 +42,15 @@ describe('Group API', () => {
         });
         it('can fail fetching a single group', async () => {
             expect.assertions(1);
-            return await expect(group.getInfo()).rejects.toEqual(undefined);
+            return await expect(group.getInfo()).rejects.toEqual(mockFailed);
         });
         it("can fail fetching a group's users", async () => {
             expect.assertions(1);
-            return await expect(group.getUsers()).rejects.toEqual(undefined);
+            return await expect(group.getUsers()).rejects.toEqual(mockFailed);
         });
         it('can fail deleting a group', async () => {
             expect.assertions(1);
-            return await expect(group.delete()).rejects.toEqual(undefined);
+            return await expect(group.delete()).rejects.toEqual(mockFailed);
         });
         it('can fail removing a user from a group', async () => {
             expect.assertions(1);

--- a/__tests__/learningPath.errors.test.js
+++ b/__tests__/learningPath.errors.test.js
@@ -2,12 +2,14 @@
 jest.unmock('../learningPath.js');
 import { LearningPathManager, LearningPath } from '../learningPath.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -19,17 +21,17 @@ describe('Learning Path API', () => {
         });
         it('can fail getting the listing of all of the learning paths', async () => {
             expect.assertions(1);
-            return await expect(lpm.getLearningPaths()).rejects.toEqual(undefined);
+            return await expect(lpm.getLearningPaths()).rejects.toEqual(mockFailed);
         });
         it('can fail creating a learning path', async () => {
             expect.assertions(1);
             return await expect(
                 lpm.createLearningPath({ title: 'foo', name: 'bar', summary: 'baz', category: 'thing' })
-            ).rejects.toEqual(undefined);
+            ).rejects.toEqual(mockFailed);
         });
         it('can fail getting the lsting of all categories used amongst learning paths', async () => {
             expect.assertions(1);
-            return await expect(lpm.getCategories()).rejects.toEqual(undefined);
+            return await expect(lpm.getCategories()).rejects.toEqual(mockFailed);
         });
     });
     describe('operations', () => {
@@ -39,35 +41,35 @@ describe('Learning Path API', () => {
         });
         it('can fail getting a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.getInfo()).rejects.toEqual(undefined);
+            return await expect(lp.getInfo()).rejects.toEqual(mockFailed);
         });
         it('can fail updating a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.update({ title: 'bar' })).rejects.toEqual(undefined);
+            return await expect(lp.update({ title: 'bar' })).rejects.toEqual(mockFailed);
         });
         it('can fail removing a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.remove()).rejects.toEqual(undefined);
+            return await expect(lp.remove()).rejects.toEqual(mockFailed);
         });
         it('can fail cloning a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.clone('pathName')).rejects.toEqual(undefined);
+            return await expect(lp.clone('pathName')).rejects.toEqual(mockFailed);
         });
         it('can fail reverting a learning path to a specific revision', async () => {
             expect.assertions(1);
-            return await expect(lp.revertToRevision(123)).rejects.toEqual(undefined);
+            return await expect(lp.revertToRevision(123)).rejects.toEqual(mockFailed);
         });
         it('can fail adding a page to a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.addPage(123)).rejects.toEqual(undefined);
+            return await expect(lp.addPage(123)).rejects.toEqual(mockFailed);
         });
         it('can fail removing a page from a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.removePage(123)).rejects.toEqual(undefined);
+            return await expect(lp.removePage(123)).rejects.toEqual(mockFailed);
         });
         it('can fail reordering a page in a learning path', async () => {
             expect.assertions(1);
-            return await expect(lp.reorderPage(123)).rejects.toEqual(undefined);
+            return await expect(lp.reorderPage(123)).rejects.toEqual(mockFailed);
         });
     });
 });

--- a/__tests__/license.errors.test.js
+++ b/__tests__/license.errors.test.js
@@ -2,12 +2,14 @@
 jest.unmock('../license.js');
 import { License } from '../license.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -18,14 +20,14 @@ describe('License', () => {
     });
     it('can fail fetching the usage', async () => {
         expect.assertions(1);
-        return await expect(license.getUsage()).rejects.toEqual(undefined);
+        return await expect(license.getUsage()).rejects.toEqual(mockFailed);
     });
     it('can fail fetching the usage logs', async () => {
         expect.assertions(1);
-        return await expect(license.getUsageLogs()).rejects.toEqual(undefined);
+        return await expect(license.getUsageLogs()).rejects.toEqual(mockFailed);
     });
     it('can fail fetching the URL for a usage log', async () => {
         expect.assertions(1);
-        return await expect(license.getUsageLogUrl('testURL')).rejects.toEqual(undefined);
+        return await expect(license.getUsageLogUrl('testURL')).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/linkToCase.errors.test.js
+++ b/__tests__/linkToCase.errors.test.js
@@ -2,12 +2,14 @@
 jest.unmock('../linkToCase.js');
 import { LinkToCase } from '../linkToCase.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -19,7 +21,7 @@ describe('LinkToCase API', () => {
         });
         it('can fail getting a blank list of linked pages', async () => {
             expect.assertions(1);
-            return await expect(ltc.getPageLinks()).rejects.toEqual(undefined);
+            return await expect(ltc.getPageLinks()).rejects.toEqual(mockFailed);
         });
     });
 });

--- a/__tests__/page.errors.test.js
+++ b/__tests__/page.errors.test.js
@@ -1,12 +1,16 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
+
 jest.unmock('../pageBase.js');
 const Page = require.requireActual('../page.js').Page;
 const PageManager = require.requireActual('../page.js').PageManager;
@@ -18,19 +22,19 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail getting basic page info', async () => {
         expect.assertions(1);
-        return await expect(page.getInfo()).rejects.toEqual(undefined);
+        return await expect(page.getInfo()).rejects.toEqual(mockFailed);
     });
     it('can fail getting subpages of a page', async () => {
         expect.assertions(1);
-        return await expect(page.getSubpages()).rejects.toEqual(undefined);
+        return await expect(page.getSubpages()).rejects.toEqual(mockFailed);
     });
     it('can fail getting the files and subpages of a page', async () => {
         expect.assertions(1);
-        return await expect(page.getFilesAndSubpages()).rejects.toEqual(undefined);
+        return await expect(page.getFilesAndSubpages()).rejects.toEqual(mockFailed);
     });
     it('can fail getting the hierarchy tree of the current page', async () => {
         expect.assertions(1);
-        return await expect(page.getTree()).rejects.toEqual(undefined);
+        return await expect(page.getTree()).rejects.toEqual(mockFailed);
     });
     it('can fail getting the hierarchy tree IDs of the current page', async () => {
         expect.assertions(1);
@@ -38,15 +42,15 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail getting the rating information of the current page', async () => {
         expect.assertions(1);
-        return await expect(page.getRating()).rejects.toEqual(undefined);
+        return await expect(page.getRating()).rejects.toEqual(mockFailed);
     });
     it('can fail setting the rating of the current page', async () => {
         expect.assertions(1);
-        return await expect(page.rate()).rejects.toEqual(undefined);
+        return await expect(page.rate()).rejects.toEqual(mockFailed);
     });
     it('can fail getting the html template of the current page', async () => {
         expect.assertions(1);
-        return await expect(page.getHtmlTemplate()).rejects.toEqual(undefined);
+        return await expect(page.getHtmlTemplate()).rejects.toEqual(mockFailed);
     });
     it('can fail copying the current page', async () => {
         expect.assertions(1);
@@ -58,11 +62,11 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail deleting the current page', async () => {
         expect.assertions(1);
-        return await expect(page.delete()).rejects.toEqual(undefined);
+        return await expect(page.delete()).rejects.toEqual(mockFailed);
     });
     it('can fail activating a draft on the current page', async () => {
         expect.assertions(1);
-        return await expect(page.activateDraft()).rejects.toEqual(undefined);
+        return await expect(page.activateDraft()).rejects.toEqual(mockFailed);
     });
     it('can fail importing archived files on the current page', async () => {
         expect.assertions(1);
@@ -70,7 +74,7 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail getting export information', async () => {
         expect.assertions(1);
-        return await expect(page.getExportInformation()).rejects.toEqual(undefined);
+        return await expect(page.getExportInformation()).rejects.toEqual(mockFailed);
     });
     it('can fail exporting current page as pdf', async () => {
         expect.assertions(1);
@@ -83,11 +87,11 @@ describe('Plug Error handling for the page.js module', () => {
                 showToc: true,
                 dryRun: true
             })
-        ).rejects.toEqual(undefined);
+        ).rejects.toEqual(mockFailed);
     });
     it('can fail setting order of current page', async () => {
         expect.assertions(1);
-        return await expect(page.setOrder()).rejects.toEqual(undefined);
+        return await expect(page.setOrder()).rejects.toEqual(mockFailed);
     });
     it('can fail getting link details on current page', async () => {
         expect.assertions(1);
@@ -99,19 +103,19 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail getting getting hierarchy info on current page', async () => {
         expect.assertions(1);
-        return await expect(page.getHierarchyInfo()).rejects.toEqual(undefined);
+        return await expect(page.getHierarchyInfo()).rejects.toEqual(mockFailed);
     });
     it('can fail posting link to case info on current page', async () => {
         expect.assertions(1);
-        return await expect(page.linkToCase('linkName')).rejects.toEqual(undefined);
+        return await expect(page.linkToCase('linkName')).rejects.toEqual(mockFailed);
     });
     it('can fail removing link to case on current page', async () => {
         expect.assertions(1);
-        return await expect(page.unlinkCase('linkName')).rejects.toEqual(undefined);
+        return await expect(page.unlinkCase('linkName')).rejects.toEqual(mockFailed);
     });
     it('can fail getting link to case on current page', async () => {
         expect.assertions(1);
-        return await expect(page.getLinkedCases()).rejects.toEqual(undefined);
+        return await expect(page.getLinkedCases()).rejects.toEqual(mockFailed);
     });
 });
 
@@ -127,7 +131,7 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail getting page rating information', async () => {
         expect.assertions(1);
-        return await expect(page.getRatings([440, 441])).rejects.toEqual(undefined);
+        return await expect(page.getRatings([440, 441])).rejects.toEqual(mockFailed);
     });
     it('can fail finding pages', async () => {
         expect.assertions(1);
@@ -143,10 +147,10 @@ describe('Plug Error handling for the page.js module', () => {
     });
     it('can fail getting page templates', async () => {
         expect.assertions(1);
-        return await expect(page.getTemplates()).rejects.toEqual(undefined);
+        return await expect(page.getTemplates()).rejects.toEqual(mockFailed);
     });
     it('can fail getting popular pages', async () => {
         expect.assertions(1);
-        return await expect(page.getPopularPages()).rejects.toEqual(undefined);
+        return await expect(page.getPopularPages()).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageBase.errors.progressPlug.js
+++ b/__tests__/pageBase.errors.progressPlug.js
@@ -3,9 +3,11 @@ jest.unmock('../pageBase.js');
 jest.unmock('../page.js');
 import { Page } from '../page.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/progressPlug.js', () =>
     require.requireActual('../__mocks__/customProgressPlug.js')({
-        put: () => Promise.reject()
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -17,6 +19,6 @@ describe('Page Base', () => {
     it('can fail attaching a file to a page (with progress)', async () => {
         return await expect(
             page.attachFile({}, { name: 'test.jpg', type: 'image/jpg', size: 1000, progress: () => {} })
-        ).rejects.toEqual(undefined);
+        ).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageBase.errors.test.js
+++ b/__tests__/pageBase.errors.test.js
@@ -3,12 +3,14 @@ jest.unmock('../pageBase.js');
 jest.unmock('../page.js');
 import { Page } from '../page.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject(),
-        delete: () => Promise.reject()
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed),
+        delete: () => Promise.reject(mockFailed)
     })
 );
 
@@ -23,7 +25,7 @@ describe('Page Base', () => {
     });
     it('can fail getting page contents', async () => {
         expect.assertions(1);
-        return await expect(page.getContents()).rejects.toEqual(undefined);
+        return await expect(page.getContents()).rejects.toEqual(mockFailed);
     });
     it('can fail setting page contents', async () => {
         expect.assertions(1);
@@ -31,27 +33,27 @@ describe('Page Base', () => {
     });
     it('can fail getting page files', async () => {
         expect.assertions(1);
-        return await expect(page.getFiles()).rejects.toEqual(undefined);
+        return await expect(page.getFiles()).rejects.toEqual(mockFailed);
     });
     it('can fail attaching files with no progress', async () => {
         expect.assertions(1);
-        return await expect(page.attachFile('testName')).rejects.toEqual(undefined);
+        return await expect(page.attachFile('testName')).rejects.toEqual(mockFailed);
     });
     it('can fail getting overview', async () => {
         expect.assertions(1);
-        return await expect(page.getOverview()).rejects.toEqual(undefined);
+        return await expect(page.getOverview()).rejects.toEqual(mockFailed);
     });
     it('can fail setting overview', async () => {
         expect.assertions(1);
-        return await expect(page.setOverview({ body: 'FOO' })).rejects.toEqual(undefined);
+        return await expect(page.setOverview({ body: 'FOO' })).rejects.toEqual(mockFailed);
     });
     it('can fail getting page tags', async () => {
         expect.assertions(1);
-        return await expect(page.getTags()).rejects.toEqual(undefined);
+        return await expect(page.getTags()).rejects.toEqual(mockFailed);
     });
     it('can fail setting page tags', async () => {
         expect.assertions(1);
-        return await expect(page.setTags()).rejects.toEqual(undefined);
+        return await expect(page.setTags()).rejects.toEqual(mockFailed);
     });
     it('can fail getting recommended page tags', async () => {
         expect.assertions(1);
@@ -63,10 +65,10 @@ describe('Page Base', () => {
     });
     it('can fail getting related', async () => {
         expect.assertions(1);
-        return await expect(page.getRelated()).rejects.toEqual(undefined);
+        return await expect(page.getRelated()).rejects.toEqual(mockFailed);
     });
     it('can fail reverting', async () => {
         expect.assertions(1);
-        return await expect(page.revert({ fromRevision: 5 })).rejects.toEqual(undefined);
+        return await expect(page.revert({ fromRevision: 5 })).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageComment.errors.test.js
+++ b/__tests__/pageComment.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../pageComment.js');
@@ -17,11 +20,11 @@ describe('Page Comment', () => {
     });
     it('can fail updating page comment', async () => {
         expect.assertions(1);
-        return await expect(page.update()).rejects.toEqual(undefined);
+        return await expect(page.update()).rejects.toEqual(mockFailed);
     });
     it('can fail deleting page comment', async () => {
         expect.assertions(1);
-        return await expect(page.delete()).rejects.toEqual(undefined);
+        return await expect(page.delete()).rejects.toEqual(mockFailed);
     });
 });
 
@@ -32,6 +35,6 @@ describe('Page Comment Manager', () => {
     });
     it('can fail adding page comment', async () => {
         expect.assertions(1);
-        return await expect(page.addComment('commentText')).rejects.toEqual(undefined);
+        return await expect(page.addComment('commentText')).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageFile.errors.test.js
+++ b/__tests__/pageFile.errors.test.js
@@ -3,12 +3,14 @@ jest.unmock('../pageFileBase.js');
 jest.unmock('../pageFile.js');
 import { PageFile } from '../pageFile.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject(),
-        delete: () => Promise.reject()
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed),
+        delete: () => Promise.reject(mockFailed)
     })
 );
 
@@ -22,19 +24,19 @@ describe('Page files', () => {
             pf = null;
         });
         it('can fail getting the file info', async () => {
-            return await expect(pf.getInfo()).rejects.toEqual(undefined);
+            return await expect(pf.getInfo()).rejects.toEqual(mockFailed);
         });
         it('can fail deleting a file attachment from the page', async () => {
-            return await expect(pf.delete()).rejects.toEqual(undefined);
+            return await expect(pf.delete()).rejects.toEqual(mockFailed);
         });
         it('can fail getting the description of a file attachment', async () => {
-            return await expect(pf.getDescription()).rejects.toEqual(undefined);
+            return await expect(pf.getDescription()).rejects.toEqual(mockFailed);
         });
         it('can fail clearing the description of a file attachment', async () => {
-            return await expect(pf.clearDescription()).rejects.toEqual(undefined);
+            return await expect(pf.clearDescription()).rejects.toEqual(mockFailed);
         });
         it('can fail updating the description of a file attachment', async () => {
-            return await expect(pf.updateDescription()).rejects.toEqual(undefined);
+            return await expect(pf.updateDescription()).rejects.toEqual(mockFailed);
         });
     });
 });

--- a/__tests__/pageKcs.errors.test.js
+++ b/__tests__/pageKcs.errors.test.js
@@ -2,13 +2,15 @@
 jest.unmock('../pageKcs.js');
 import { PageKcs } from '../pageKcs.js';
 
+let mockFailed = 'MOCK FAILED';
+
 /* eslint-env jasmine, jest */
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -19,22 +21,22 @@ describe('PageKcs', () => {
     });
     it('can fail getting kcs state', async () => {
         expect.assertions(1);
-        return await expect(kcs.getState()).rejects.toEqual(undefined);
+        return await expect(kcs.getState()).rejects.toEqual(mockFailed);
     });
     it('can fail setting a kcs state', async () => {
         expect.assertions(1);
-        return await expect(kcs.setState()).rejects.toEqual(undefined);
+        return await expect(kcs.setState()).rejects.toEqual(mockFailed);
     });
     it('can fail getting kcs valid transitions', async () => {
         expect.assertions(1);
-        return await expect(kcs.getValidTransitions()).rejects.toEqual(undefined);
+        return await expect(kcs.getValidTransitions()).rejects.toEqual(mockFailed);
     });
     it('can fail initializing a kcs state', async () => {
         expect.assertions(1);
-        return await expect(kcs.initialize()).rejects.toEqual(undefined);
+        return await expect(kcs.initialize()).rejects.toEqual(mockFailed);
     });
     it('can fail setting a kcs flag state', async () => {
         expect.assertions(1);
-        return await expect(kcs.setFlag({ state: false }, 'flagDetail')).rejects.toEqual(undefined);
+        return await expect(kcs.setFlag({ state: false }, 'flagDetail')).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageProperty.errors.test.js
+++ b/__tests__/pageProperty.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../pageProperty.js');
@@ -17,6 +20,6 @@ describe('Page Property', () => {
     });
     it('can fail getting listing of page properties for a hierarchy of pages', async () => {
         expect.assertions(1);
-        return await expect(page.getPropertyForChildren(123)).rejects.toEqual(undefined);
+        return await expect(page.getPropertyForChildren(123)).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pagePropertyBase.errors.test.js
+++ b/__tests__/pagePropertyBase.errors.test.js
@@ -4,12 +4,14 @@ jest.unmock('../pagePropertyBase.js');
 
 import { PageProperty } from '../pageProperty.js';
 
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -20,24 +22,24 @@ describe('Page Property', () => {
     });
     it('can fail getting listing of page properties for a hierarchy of pages', async () => {
         expect.assertions(1);
-        return await expect(page.getProperties(['propName'])).rejects.toEqual(undefined);
+        return await expect(page.getProperties(['propName'])).rejects.toEqual(mockFailed);
     });
     it('can fail getting listing of page property contents', async () => {
         expect.assertions(1);
-        return await expect(page.getPropertyContents(123)).rejects.toEqual(undefined);
+        return await expect(page.getPropertyContents(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting single page property', async () => {
         expect.assertions(1);
-        return await expect(page.getProperty(123)).rejects.toEqual(undefined);
+        return await expect(page.getProperty(123)).rejects.toEqual(mockFailed);
     });
     it('can fail setting page property on the page', async () => {
         expect.assertions(1);
         return await expect(
             page.setProperty('property1', { text: 'property text', type: 'text/plain' })
-        ).rejects.toEqual(undefined);
+        ).rejects.toEqual(mockFailed);
     });
     it('can fail deleting page property on the page', async () => {
         expect.assertions(1);
-        return await expect(page.deleteProperty(123)).rejects.toEqual(undefined);
+        return await expect(page.deleteProperty(123)).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageSecurity.errors.test.js
+++ b/__tests__/pageSecurity.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../pageSecurity.js');
@@ -17,18 +20,18 @@ describe('Page Comment', () => {
     });
     it('can fail getting the pages security info', async () => {
         expect.assertions(1);
-        return await expect(page.get()).rejects.toEqual(undefined);
+        return await expect(page.get()).rejects.toEqual(mockFailed);
     });
     it('can fail resetting the pages security info', async () => {
         expect.assertions(1);
-        return await expect(page.reset()).rejects.toEqual(undefined);
+        return await expect(page.reset()).rejects.toEqual(mockFailed);
     });
     it('can fail setting the pages security info', async () => {
         expect.assertions(1);
-        return await expect(page.set({ pageRestriction: 'Public' })).rejects.toEqual(undefined);
+        return await expect(page.set({ pageRestriction: 'Public' })).rejects.toEqual(mockFailed);
     });
     it('can fail updating the pages security info', async () => {
         expect.assertions(1);
-        return await expect(page.update()).rejects.toEqual(undefined);
+        return await expect(page.update()).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/pageSubscription.errors.test.js
+++ b/__tests__/pageSubscription.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../pageSubscription.js');
@@ -17,11 +20,11 @@ describe('Page Subscriptions', () => {
     });
     it('can fail subscribing to a page as the current user', async () => {
         expect.assertions(1);
-        return await expect(page.subscribe()).rejects.toEqual(undefined);
+        return await expect(page.subscribe()).rejects.toEqual(mockFailed);
     });
     it('can fail unsubscribing to a page as the current user', async () => {
         expect.assertions(1);
-        return await expect(page.unsubscribe()).rejects.toEqual(undefined);
+        return await expect(page.unsubscribe()).rejects.toEqual(mockFailed);
     });
 });
 
@@ -32,6 +35,6 @@ describe('Page Subscription Manager', () => {
     });
     it('can fail getting all page subscriptions', async () => {
         expect.assertions(1);
-        return await expect(page.getSubscriptions()).rejects.toEqual(undefined);
+        return await expect(page.getSubscriptions()).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/site.errors.test.js
+++ b/__tests__/site.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../site.js');
@@ -17,64 +20,64 @@ describe('Page Subscriptions', () => {
     });
     it('can fail getting site activity logs', async () => {
         expect.assertions(1);
-        return await expect(site.getSiteActivityLogs()).rejects.toEqual(undefined);
+        return await expect(site.getSiteActivityLogs()).rejects.toEqual(mockFailed);
     });
     it('can fail getting search query logs', async () => {
         expect.assertions(1);
-        return await expect(site.getSearchQueryLogs()).rejects.toEqual(undefined);
+        return await expect(site.getSearchQueryLogs()).rejects.toEqual(mockFailed);
     });
     it('can fail getting single resource string', async () => {
         expect.assertions(1);
-        return await expect(site.getResourceString({ key: 'Test.Resource.key' })).rejects.toEqual(undefined);
+        return await expect(site.getResourceString({ key: 'Test.Resource.key' })).rejects.toEqual(mockFailed);
     });
     it('can fail getting multiple resource strings', async () => {
         expect.assertions(1);
         return await expect(site.getResourceStrings({ keys: ['foo.bar.baz'], lang: 'en-us' })).rejects.toEqual(
-            undefined
+            mockFailed
         );
     });
     it('can fail getting search query log url', async () => {
         expect.assertions(1);
-        return await expect(site.getSearchQueryLogUrl('searchqueries-2016-10-000')).rejects.toEqual(undefined);
+        return await expect(site.getSearchQueryLogUrl('searchqueries-2016-10-000')).rejects.toEqual(mockFailed);
     });
     it('can fail getting site activity log url', async () => {
         expect.assertions(1);
-        return await expect(site.getSiteActivityLogUrl('searchqueries-2016-10-000')).rejects.toEqual(undefined);
+        return await expect(site.getSiteActivityLogUrl('searchqueries-2016-10-000')).rejects.toEqual(mockFailed);
     });
     it('can fail getting page tags', async () => {
         expect.assertions(1);
-        return await expect(site.getTags()).rejects.toEqual(undefined);
+        return await expect(site.getTags()).rejects.toEqual(mockFailed);
     });
     it('can fail setting page tags', async () => {
         expect.assertions(1);
-        return await expect(site.setTags()).rejects.toEqual(undefined);
+        return await expect(site.setTags()).rejects.toEqual(mockFailed);
     });
     it('can fail searching across the site', async () => {
         expect.assertions(1);
-        return await expect(site.search()).rejects.toEqual(undefined);
+        return await expect(site.search()).rejects.toEqual(mockFailed);
     });
     it('can fail searching site index across the site', async () => {
         expect.assertions(1);
-        return await expect(site.searchIndex()).rejects.toEqual(undefined);
+        return await expect(site.searchIndex()).rejects.toEqual(mockFailed);
     });
     it('can fail getting search analytics across the site', async () => {
         expect.assertions(1);
-        return await expect(site.getSearchAnalytics(123)).rejects.toEqual(undefined);
+        return await expect(site.getSearchAnalytics(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting search analytics for a given period for a given query', async () => {
         expect.assertions(1);
-        return await expect(site.getSearchAnalyticsQuery(123)).rejects.toEqual(undefined);
+        return await expect(site.getSearchAnalyticsQuery(123)).rejects.toEqual(mockFailed);
     });
     it('can fail getting site activity stats for a given site', async () => {
         expect.assertions(1);
-        return await expect(site.getActivity()).rejects.toEqual(undefined);
+        return await expect(site.getActivity()).rejects.toEqual(mockFailed);
     });
     it('can fail getting site roles', async () => {
         expect.assertions(1);
-        return await expect(site.getRoles()).rejects.toEqual(undefined);
+        return await expect(site.getRoles()).rejects.toEqual(mockFailed);
     });
     it('can fail sending feedback to the site owner', async () => {
         expect.assertions(1);
-        return await expect(site.sendFeedback({ comment: 'commentString' })).rejects.toEqual(undefined);
+        return await expect(site.sendFeedback({ comment: 'commentString' })).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/siteJob.errors.test.js
+++ b/__tests__/siteJob.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../siteJob.js');
@@ -36,12 +39,12 @@ describe('Error handling for the siteJobs.js module', () => {
     it('can fail scheduling a site export', async () => {
         const sjm = new SiteJobManager();
         expect.assertions(1);
-        return await expect(sjm.scheduleExport(exportParams)).rejects.toEqual(undefined);
+        return await expect(sjm.scheduleExport(exportParams)).rejects.toEqual(mockFailed);
     });
     it('can fail scheduling a site import', async () => {
         const sjm = new SiteJobManager();
         expect.assertions(1);
-        return await expect(sjm.scheduleImport(importParams)).rejects.toEqual(undefined);
+        return await expect(sjm.scheduleImport(importParams)).rejects.toEqual(mockFailed);
     });
     it('can fail if the response to getting a job status is an error', async () => {
         const sj = new SiteJob('3c07ca9c-49c0-4097-8eea-8e29e96461ec');

--- a/__tests__/user.errors.test.js
+++ b/__tests__/user.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 
@@ -22,7 +25,7 @@ describe('Plug Error handling for the user.js User module', () => {
     });
     it('can handle a rejection properly for User.prototype.getInfo', async () => {
         expect.assertions(1);
-        return await expect(user.getInfo()).rejects.toEqual(undefined);
+        return await expect(user.getInfo()).rejects.toEqual(mockFailed);
     });
     it('can handle a rejection properly for User.prototype.setPassword', async () => {
         expect.assertions(1);
@@ -30,7 +33,7 @@ describe('Plug Error handling for the user.js User module', () => {
     });
     it('can handle a rejection properly for User.prototype.checkAllowed', async () => {
         expect.assertions(1);
-        return await expect(user.checkAllowed([123])).rejects.toEqual(undefined);
+        return await expect(user.checkAllowed([123])).rejects.toEqual(mockFailed);
     });
 });
 
@@ -41,18 +44,18 @@ describe('Plug Error handling for the user.js UserManager module', () => {
     });
     it('can handle a rejection properly for UserManager.prototype.getCurrentUser', async () => {
         expect.assertions(1);
-        return await expect(user.getCurrentUser()).rejects.toEqual(undefined);
+        return await expect(user.getCurrentUser()).rejects.toEqual(mockFailed);
     });
     it('can handle a rejection properly for UserManager.prototype.getCurrentUserActivityToken', async () => {
         expect.assertions(1);
-        return await expect(user.getCurrentUserActivityToken()).rejects.toEqual(undefined);
+        return await expect(user.getCurrentUserActivityToken()).rejects.toEqual(mockFailed);
     });
     it('can handle a rejection properly for UserManager.prototype.getUsers', async () => {
         expect.assertions(1);
-        return await expect(user.getUsers()).rejects.toEqual(undefined);
+        return await expect(user.getUsers()).rejects.toEqual(mockFailed);
     });
     it('can handle a rejection properly for UserManager.prototype.searchUsers', async () => {
         expect.assertions(1);
-        return await expect(user.searchUsers({ username: 'foo', limit: 20 })).rejects.toEqual(undefined);
+        return await expect(user.searchUsers({ username: 'foo', limit: 20 })).rejects.toEqual(mockFailed);
     });
 });

--- a/__tests__/webWidgets.errors.test.js
+++ b/__tests__/webWidgets.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 const WebWidgetsManager = require.requireActual('../webWidgets.js').WebWidgetsManager;

--- a/__tests__/workflows.errors.test.js
+++ b/__tests__/workflows.errors.test.js
@@ -1,10 +1,13 @@
 /* eslint-env jasmine, jest */
+
+let mockFailed = 'MOCK FAILED';
+
 jest.mock('/mindtouch-http.js/plug.js', () =>
     require.requireActual('../__mocks__/customPlug.js')({
-        delete: () => Promise.reject(),
-        get: () => Promise.reject(),
-        post: () => Promise.reject(),
-        put: () => Promise.reject()
+        delete: () => Promise.reject(mockFailed),
+        get: () => Promise.reject(mockFailed),
+        post: () => Promise.reject(mockFailed),
+        put: () => Promise.reject(mockFailed)
     })
 );
 jest.unmock('../workflows.js');
@@ -18,19 +21,19 @@ describe('Workflows', () => {
         });
         it('can fail submitting page feedback', async () => {
             expect.assertions(1);
-            return await expect(wm.submitFeedback({ _path: 'foo' })).rejects.toEqual(undefined);
+            return await expect(wm.submitFeedback({ _path: 'foo' })).rejects.toEqual(mockFailed);
         });
         it('can fail requesting an article be created on the site', async () => {
             expect.assertions(1);
-            return await expect(wm.requestArticle()).rejects.toEqual(undefined);
+            return await expect(wm.requestArticle()).rejects.toEqual(mockFailed);
         });
         it('can fail submitting a support issue', async () => {
             expect.assertions(1);
-            return await expect(wm.submitIssue({ _path: 'foo', _search: 'bar' })).rejects.toEqual(undefined);
+            return await expect(wm.submitIssue({ _path: 'foo', _search: 'bar' })).rejects.toEqual(mockFailed);
         });
         it('can fail contacting site suppport', async () => {
             expect.assertions(1);
-            return await expect(wm.contactSupport({ _path: 'foo', _search: 'bar' })).rejects.toEqual(undefined);
+            return await expect(wm.contactSupport({ _path: 'foo', _search: 'bar' })).rejects.toEqual(mockFailed);
         });
     });
 });

--- a/pageKcs.js
+++ b/pageKcs.js
@@ -4,7 +4,6 @@ import { modelParser } from './lib/modelParser.js';
 import { utility } from './lib/utility.js';
 import { kcsTransitionsModel } from './models/kcsTransitions.model.js';
 import { kcsStateModel } from './models/kcsState.model.js';
-import { apiErrorModel } from './models/apiError.model.js';
 
 /**
  * A class for handling KCS actions

--- a/pageKcs.js
+++ b/pageKcs.js
@@ -6,8 +6,6 @@ import { kcsTransitionsModel } from './models/kcsTransitions.model.js';
 import { kcsStateModel } from './models/kcsState.model.js';
 import { apiErrorModel } from './models/apiError.model.js';
 
-const _errorParser = modelParser.createParser(apiErrorModel);
-
 /**
  * A class for handling KCS actions
  */

--- a/pagePropertyBase.js
+++ b/pagePropertyBase.js
@@ -2,7 +2,6 @@ import { utility } from './lib/utility.js';
 import { modelParser } from './lib/modelParser.js';
 import { pagePropertiesModel } from './models/pageProperties.model.js';
 import { pagePropertyModel } from './models/pageProperty.model.js';
-import { apiErrorModel } from './models/apiError.model.js';
 
 export class PagePropertyBase {
     constructor(id) {

--- a/pagePropertyBase.js
+++ b/pagePropertyBase.js
@@ -4,8 +4,6 @@ import { pagePropertiesModel } from './models/pageProperties.model.js';
 import { pagePropertyModel } from './models/pageProperty.model.js';
 import { apiErrorModel } from './models/apiError.model.js';
 
-const _errorParser = modelParser.createParser(apiErrorModel);
-
 export class PagePropertyBase {
     constructor(id) {
         if (this.constructor.name === 'PagePropertyBase') {


### PR DESCRIPTION
Ticket: MTP-7809

Summary:
-Updated all tests to reject _plug http promises with String value versus Undefined object
-Removed unused errorParser values
-Removed unused imports