### PR TITLE
Martian model additions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1075,6 +1075,8 @@ const pageModel = [
     { field: 'language.effective', name: 'languageEffective' },
     { field: 'timeuuid' },
     { field: ['path', '#text'] },
+    { field: ['path', '@type'], name: 'pathType' },
+    { field: ['path', '@seo'], name: 'pathSeo', transform: 'boolean' },
     { field: 'restriction' },
     { field: '@revision', name: 'revision', transform: 'number' },
     {
@@ -3593,13 +3595,15 @@ class GroupManager {
 }
 
 const learningPathModel = [
-    { field: 'title' },
     { field: '@name', name: 'name' },
-    { field: 'summary' },
-    { field: 'pages', isArray: true, transform: pageModel },
+    { field: '@editable', name: 'editable', transform: 'boolean' },
+    { field: '@revision', name: 'revision', transform: 'number' },
     { field: 'edittime', name: 'editTime' },
+    { field: 'title' },
+    { field: 'summary' },
+    { field: 'category' },
     { field: 'uri.learningpath', name: 'uri' },
-    { field: 'category' }
+    { field: 'pages', isArray: true, transform: pageModel }
 ];
 
 const learningPathsModel = [
@@ -3621,7 +3625,7 @@ class LearningPath {
 
     /**
      * Get the learning path data.
-     * @param {String|Number} revision The positive integer or GUID that refers to a specific revision to fetch. If not supplied, the latest revision will be fetched.
+     * @param {String|Number} [revision] The positive integer or GUID that refers to a specific revision to fetch. If not supplied, the latest revision will be fetched.
      * @returns {Promise} A promise that, when resolved, yields a learningPathModel representing the learning path.
      */
     getInfo(revision) {

--- a/docs/learningPath.js.html
+++ b/docs/learningPath.js.html
@@ -48,7 +48,7 @@ export class LearningPath {
 
     /**
      * Get the learning path data.
-     * @param {String|Number} revision The positive integer or GUID that refers to a specific revision to fetch. If not supplied, the latest revision will be fetched.
+     * @param {String|Number} [revision] The positive integer or GUID that refers to a specific revision to fetch. If not supplied, the latest revision will be fetched.
      * @returns {Promise} A promise that, when resolved, yields a learningPathModel representing the learning path.
      */
     getInfo(revision) {

--- a/learningPath.js
+++ b/learningPath.js
@@ -20,7 +20,7 @@ export class LearningPath {
 
     /**
      * Get the learning path data.
-     * @param {String|Number} revision The positive integer or GUID that refers to a specific revision to fetch. If not supplied, the latest revision will be fetched.
+     * @param {String|Number} [revision] The positive integer or GUID that refers to a specific revision to fetch. If not supplied, the latest revision will be fetched.
      * @returns {Promise} A promise that, when resolved, yields a learningPathModel representing the learning path.
      */
     getInfo(revision) {

--- a/models/__mocks__/page/simple.mock.json
+++ b/models/__mocks__/page/simple.mock.json
@@ -10,6 +10,7 @@
   "namespace": "main",
   "path": {
     "@seo": "true",
+    "@type": "custom",
     "#text": "Category_2/Page_Title"
   },
   "path.original": "Category_2/Page_Title_Original",

--- a/models/learningPath.model.js
+++ b/models/learningPath.model.js
@@ -1,11 +1,13 @@
 import { pageModel } from './page.model.js';
 
 export const learningPathModel = [
-    { field: 'title' },
     { field: '@name', name: 'name' },
-    { field: 'summary' },
-    { field: 'pages', isArray: true, transform: pageModel },
+    { field: '@editable', name: 'editable', transform: 'boolean' },
+    { field: '@revision', name: 'revision', transform: 'number' },
     { field: 'edittime', name: 'editTime' },
+    { field: 'title' },
+    { field: 'summary' },
+    { field: 'category' },
     { field: 'uri.learningpath', name: 'uri' },
-    { field: 'category' }
+    { field: 'pages', isArray: true, transform: pageModel }
 ];

--- a/models/page.model.js
+++ b/models/page.model.js
@@ -16,6 +16,8 @@ const pageModel = [
     { field: 'language.effective', name: 'languageEffective' },
     { field: 'timeuuid' },
     { field: ['path', '#text'] },
+    { field: ['path', '@type'], name: 'pathType' },
+    { field: ['path', '@seo'], name: 'pathSeo', transform: 'boolean' },
     { field: 'restriction' },
     { field: '@revision', name: 'revision', transform: 'number' },
     {


### PR DESCRIPTION
- Add editable and revision fields to learningPath.model
- Add `pathType` and `pathSeo` fields to page model
- Docs fix: Make the `revision` function parameter optional in LearningPath.prototype.getInfo